### PR TITLE
[python] Merge classpaths for RayDP jars with user-specified jars.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,7 @@ target/
 .vscode
 
 examples/.ipynb_checkpoints/
+
+# Vim temp files
+*.swp
+*.swo

--- a/python/raydp/spark/ray_cluster.py
+++ b/python/raydp/spark/ray_cluster.py
@@ -56,7 +56,11 @@ class SparkCluster(Cluster):
         extra_conf["spark.executor.instances"] = str(num_executors)
         extra_conf["spark.executor.cores"] = str(executor_cores)
         extra_conf["spark.executor.memory"] = str(executor_memory)
-        extra_conf["spark.jars"] = ",".join(glob.glob(RAYDP_CP))
+        try:
+            extra_jars = [extra_conf["spark.jars"]]
+        except KeyError:
+            extra_jars = []
+        extra_conf["spark.jars"] = ",".join(glob.glob(RAYDP_CP) + extra_jars)
         driver_cp = "spark.driver.extraClassPath"
         if driver_cp in extra_conf:
             extra_conf[driver_cp] = ":".join(glob.glob(RAYDP_CP)) + ":" + extra_conf[driver_cp]


### PR DESCRIPTION
Currently, the user is unable to specify jars that they wish to be added to the Spark driver and executor classpaths, which is a common need for e.g. [reading/writing Parquet files from/to S3](https://hadoop.apache.org/docs/r2.8.0/hadoop-aws/tools/hadoop-aws/index.html#ClassNotFoundException:_org.apache.hadoop.fs.s3a.S3AFileSystem). This PR merges any user-specified jars with the RayDP jars, so that all jars will be on the driver and executor classpaths.