### PR TITLE
A quick fix for issue #94

### DIFF
--- a/python/raydp/tests/test_torch_sequential.py
+++ b/python/raydp/tests/test_torch_sequential.py
@@ -1,0 +1,57 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import pytest
+import sys
+import torch
+import raydp
+from raydp.torch import TorchEstimator
+
+def test_torch_estimator(spark_session):
+    ##prepare the data
+    customers = [
+        (1,'James', 21, 6),
+        (2, "Liz", 25, 8),
+        (3, "John", 31, 6),
+        (4, "Jennifer", 45, 7),
+        (5, "Robert", 41, 5),
+        (6, "Sandra", 45, 8)
+    ]
+    df = spark_session.createDataFrame(customers, ["cID", "name", "age", "grade"])
+    
+    ##create model
+    model = torch.nn.Sequential(torch.nn.Linear(1, 2), torch.nn.Linear(2,1))
+    optimizer = torch.optim.Adam(model.parameters())
+    loss = torch.nn.MSELoss()
+
+    #config
+    estimator = TorchEstimator(
+        model = model,
+        optimizer = optimizer,
+        loss = loss,
+        num_workers = 3,
+        num_epochs = 5,
+        feature_columns = ["age"],
+        label_column = ["grade"],
+        batch_size=2
+    )
+    estimator.fit_on_spark(df)
+
+    estimator.shutdown()
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", __file__]))

--- a/python/raydp/tests/test_torch_sequential.py
+++ b/python/raydp/tests/test_torch_sequential.py
@@ -21,7 +21,7 @@ import torch
 import raydp
 from raydp.torch import TorchEstimator
 
-def test_torch_estimator(spark_session):
+def test_torch_estimator(spark_on_ray_small):
     ##prepare the data
     customers = [
         (1,'James', 21, 6),
@@ -31,8 +31,8 @@ def test_torch_estimator(spark_session):
         (5, "Robert", 41, 5),
         (6, "Sandra", 45, 8)
     ]
-    df = spark_session.createDataFrame(customers, ["cID", "name", "age", "grade"])
-    
+    df = spark_on_ray_small.createDataFrame(customers, ["cID", "name", "age", "grade"])
+
     ##create model
     model = torch.nn.Sequential(torch.nn.Linear(1, 2), torch.nn.Linear(2,1))
     optimizer = torch.optim.Adam(model.parameters())

--- a/python/raydp/torch/estimator.py
+++ b/python/raydp/torch/estimator.py
@@ -209,12 +209,15 @@ class TorchEstimator(EstimatorInterface, SparkEstimatorInterface):
                 else:
                     lr_scheduler = None
 
+                # A quick work-around for https://github.com/ray-project/ray/issues/14352
+                # As we only support single model for now, this is OK
                 registered = self.register(
-                    models=model, optimizers=optimizer, criterion=loss, schedulers=lr_scheduler)
+                    models=[model], optimizers=optimizer, criterion=loss, schedulers=lr_scheduler)
                 if lr_scheduler is not None:
                     self.model, self.optimizer, self.criterion, self.scheduler = registered
                 else:
                     self.model, self.optimizer, self.criterion = registered
+                self.model = self.model[0]
 
                 # create dataset
                 batch_size = config["batch_size"]

--- a/python/raydp/torch/estimator.py
+++ b/python/raydp/torch/estimator.py
@@ -212,12 +212,15 @@ class TorchEstimator(EstimatorInterface, SparkEstimatorInterface):
                 # A quick work-around for https://github.com/ray-project/ray/issues/14352
                 # As we only support single model for now, this is OK
                 registered = self.register(
-                    models=[model], optimizers=optimizer, criterion=loss, schedulers=lr_scheduler)
+                    models=[model], optimizers=[optimizer], criterion=loss, \
+                        schedulers=[lr_scheduler] if lr_scheduler is not None else None)
                 if lr_scheduler is not None:
                     self.model, self.optimizer, self.criterion, self.scheduler = registered
+                    self.scheduler = self.scheduler[0]
                 else:
                     self.model, self.optimizer, self.criterion = registered
                 self.model = self.model[0]
+                self.optimizer = self.optimizer[0]
 
                 # create dataset
                 batch_size = config["batch_size"]


### PR DESCRIPTION
In current ray versions,  models like Sequential in pytorch, which implements Iterable interface, will be treated as a list of models. A quick work-around for this is to pass in our single model as a list, then unpack it afterwards.  