### PR TITLE
add a workflow to automatically upload to pypi

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -43,3 +43,4 @@ jobs:
       uses: pypa/gh-action-pypi-publish@master
       with:
         password: ${{ secrets.PYPI_API_TOKEN }}
+        skip_existing: true

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -18,8 +18,8 @@
 name: RayDP PyPi
 
 on: 
-  push:
-    branches: [ master ]
+  schedule:
+    - cron: '0 0 * * *'
   # can manually trigger the workflow
   workflow_dispatch:
 
@@ -36,6 +36,8 @@ jobs:
       with:
         python-version: 3.7
     - name: Build wheel
+      env:
+        RAYDP_PACKAGE_NAME: raydp_nightly
       run: pip install wheel && ./build.sh
     - name: Upload
       uses: pypa/gh-action-pypi-publish@master

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -35,6 +35,10 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: 3.7
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
     - name: Build wheel
       env:
         RAYDP_PACKAGE_NAME: raydp_nightly

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,0 +1,43 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: RayDP PyPi
+
+on: 
+  push:
+    branches: [ master ]
+  # can manually trigger the workflow
+  workflow_dispatch:
+
+jobs:
+  build-and-publish:
+    # do not run in forks
+    if: ${{ startsWith(github.ref, 'refs/tags') && (github.repository_owner == 'oap-project') }}
+    name: build wheel and upload
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+    - name: Build wheel
+      run: pip install wheel && ./build.sh
+    - name: Upload
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/build.sh
+++ b/build.sh
@@ -43,10 +43,11 @@ mvn clean package -q -DskipTests
 popd # core dir
 
 # build python part
+RAYDP_PACKAGE_NAME=${RAYDP_PACKAGE_NAME:-raydp}
 PYTHON_DIR="${CURRENT_DIR}/python"
 pushd ${PYTHON_DIR}
 python setup.py bdist_wheel
-cp ${PYTHON_DIR}/dist/raydp-* ${DIST_PATH}
+cp ${PYTHON_DIR}/dist/${RAYDP_PACKAGE_NAME}-* ${DIST_PATH}
 popd # python dir
 
 set +ex

--- a/python/setup.py
+++ b/python/setup.py
@@ -20,14 +20,13 @@ import io
 import os
 import sys
 from shutil import copy2, rmtree
-from datetime import datetime
 
 from setuptools import find_packages
 from setuptools import setup
 
 package_name = os.getenv("RAYDP_PACKAGE_NAME", "raydp")
 if package_name == 'raydp_nightly':
-    VERSION = datetime.today().strftime('%Y%m%d')
+    VERSION = 'dev'
 else:
     VERSION = "0.2.0.dev0"
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -20,11 +20,16 @@ import io
 import os
 import sys
 from shutil import copy2, rmtree
+from datetime import datetime
 
 from setuptools import find_packages
 from setuptools import setup
 
-VERSION = "0.2.0.dev0"
+package_name = os.getenv("RAYDP_PACKAGE_NAME", "raydp")
+if package_name == 'raydp_nightly':
+    VERSION = datetime.today().strftime('%Y%m%d')
+else:
+    VERSION = "0.2.0.dev0"
 
 ROOT_DIR = os.path.dirname(__file__)
 
@@ -66,7 +71,7 @@ try:
     _packages.append("raydp.jars")
 
     setup(
-        name="raydp",
+        name=package_name,
         version=VERSION,
         author="RayDP Developers",
         author_email="raydp-dev@googlegroups.com",


### PR DESCRIPTION
This workflow can upload the package to pypi whenever a tagged release is pushed to master.  Besides, we can also trigger the workflow manually. 
We @carsonwang  need to add a token to this repo before we can use it, as mentioned [here](https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/)

The nightly release is not prepared yet. Because pypi has a total size limit for each project, I think maybe we don't need to upload it nightly. Actually, building the python part is very easy, users should be able to do it. The problem is to build the java & scala part, as they have many dependencies.  Therefore, maybe we can release jar separately, and tell users how to build the package with a built jar, or modify the path to jar.