### PR TITLE
fix nightly build and update readme

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -26,7 +26,7 @@ on:
 jobs:
   build-and-publish:
     # do not run in forks
-    if: ${{ startsWith(github.ref, 'refs/tags') && (github.repository_owner == 'oap-project') }}
+    if: ${{ github.repository_owner == 'oap-project' }}
     name: build wheel and upload
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ You can install latest RayDP using pip. RayDP requires Ray (>=1.1.0) and PySpark
 pip install raydp
 ```
 
+Or you can install our nightly build:
+```shell
+pip install raydp-nightly
+```
+
 If you'd like to build and install the latest master, use the following command:
 
 ```shell

--- a/python/setup.py
+++ b/python/setup.py
@@ -20,13 +20,14 @@ import io
 import os
 import sys
 from shutil import copy2, rmtree
+from datetime import datetime
 
 from setuptools import find_packages
 from setuptools import setup
 
 package_name = os.getenv("RAYDP_PACKAGE_NAME", "raydp")
 if package_name == 'raydp_nightly':
-    VERSION = 'dev'
+    VERSION = datetime.today().strftime("%Y.%m.%d.dev0")
 else:
     VERSION = "0.2.0.dev0"
 


### PR DESCRIPTION
I forgot to delete a condition in the last PR, so the scheduled run today was skipped.  Besides, pypi does not override versions,  so I change the version to be unique. We need to delete releases once we reach [project size limit](https://pypi.org/help/#project-size-limit). 
I also update the readme to include instructions for installing the nightly build.