### PR TITLE
Switch to memory units in bytes

### DIFF
--- a/core/src/main/java/org/apache/spark/raydp/AppMasterJavaUtils.java
+++ b/core/src/main/java/org/apache/spark/raydp/AppMasterJavaUtils.java
@@ -24,13 +24,12 @@ import java.util.Map;
 import org.apache.spark.executor.RayCoarseGrainedExecutorBackend;
 
 public class AppMasterJavaUtils {
-  private static int MEMORY_RESOURCE_UNIT_BYTES = 50 * 1024 * 1024;
 
   /**
-   * Convert from mbs -> memory units. The memory units in ray is 50 * 1024 * 1024
+   * Convert from mbs -> memory units. The memory units in ray is bytes
    */
   private static double toMemoryUnits(int memoryInMB) {
-    double result = 1.0 * memoryInMB * 1024 * 1024 / MEMORY_RESOURCE_UNIT_BYTES;
+    double result = 1.0 * memoryInMB * 1024 * 1024;
     return result;
   }
 


### PR DESCRIPTION
Ray switched to memory units in bytes in this [PR](https://github.com/ray-project/ray/pull/14433)
This PR changes RayDP to use bytes unit, 