### PR TITLE
only upload to pypi when the commit time is within last 24 hrs

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -24,9 +24,21 @@ on:
   workflow_dispatch:
 
 jobs:
+  check-commit-date:
+    name: check commit date is today
+    run: |
+         :
+         timestamp=$(git log --no-walk --date=unix --format=%cd $GITHUB_SHA)
+         echo $GITHUB_SHA
+         days=$(( ( $(date --utc +%s) - $timestamp ) / 86400 ))
+         echo $days
+         if [ $days -eq 0 ]; then
+            echo COMMIT_SINCE_LAST_UPLOAD=true >> $GITHUB_ENV
+         fi
   build-and-publish:
     # do not run in forks
-    if: ${{ github.repository_owner == 'oap-project' }}
+    # if: ${{ github.repository_owner == 'oap-project' }}
+    if: env.COMMIT_SINCE_LAST_UPLOAD == 'true'
     name: build wheel and upload
     runs-on: ubuntu-latest
     steps:
@@ -46,5 +58,6 @@ jobs:
     - name: Upload
       uses: pypa/gh-action-pypi-publish@master
       with:
-        password: ${{ secrets.PYPI_API_TOKEN }}
-        skip_existing: true
+        # password: ${{ secrets.PYPI_API_TOKEN }}
+        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -24,23 +24,9 @@ on:
   workflow_dispatch:
 
 jobs:
-  check-commit-date:
-    name: check commit date is today
-    steps:
-    - name: days since the commit date
-      run: |
-          :
-          timestamp=$(git log --no-walk --date=unix --format=%cd $GITHUB_SHA)
-          echo $GITHUB_SHA
-          days=$(( ( $(date --utc +%s) - $timestamp ) / 86400 ))
-          echo $days
-          if [ $days -eq 0 ]; then
-              echo COMMIT_SINCE_LAST_UPLOAD=true >> $GITHUB_ENV
-          fi
   build-and-publish:
     # do not run in forks
     # if: ${{ github.repository_owner == 'oap-project' }}
-    if: env.COMMIT_SINCE_LAST_UPLOAD == 'true'
     name: build wheel and upload
     runs-on: ubuntu-latest
     steps:
@@ -53,11 +39,23 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 1.8
+    - name: days since the commit date
+      run: |
+          :
+          timestamp=$(git log --no-walk --date=unix --format=%cd $GITHUB_SHA)
+          echo $GITHUB_SHA
+          days=$(( ( $(date --utc +%s) - $timestamp ) / 86400 ))
+          echo $days
+          if [ $days -eq 0 ]; then
+              echo COMMIT_SINCE_LAST_UPLOAD=true >> $GITHUB_ENV
+          fi
     - name: Build wheel
+      if: env.COMMIT_SINCE_LAST_UPLOAD == 'true'
       env:
         RAYDP_PACKAGE_NAME: raydp_nightly
       run: pip install wheel && ./build.sh
     - name: Upload
+      if: env.COMMIT_SINCE_LAST_UPLOAD == 'true'
       uses: pypa/gh-action-pypi-publish@master
       with:
         # password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -26,15 +26,17 @@ on:
 jobs:
   check-commit-date:
     name: check commit date is today
-    run: |
-         :
-         timestamp=$(git log --no-walk --date=unix --format=%cd $GITHUB_SHA)
-         echo $GITHUB_SHA
-         days=$(( ( $(date --utc +%s) - $timestamp ) / 86400 ))
-         echo $days
-         if [ $days -eq 0 ]; then
-            echo COMMIT_SINCE_LAST_UPLOAD=true >> $GITHUB_ENV
-         fi
+    steps:
+    - name: days since the commit date
+      run: |
+          :
+          timestamp=$(git log --no-walk --date=unix --format=%cd $GITHUB_SHA)
+          echo $GITHUB_SHA
+          days=$(( ( $(date --utc +%s) - $timestamp ) / 86400 ))
+          echo $days
+          if [ $days -eq 0 ]; then
+              echo COMMIT_SINCE_LAST_UPLOAD=true >> $GITHUB_ENV
+          fi
   build-and-publish:
     # do not run in forks
     # if: ${{ github.repository_owner == 'oap-project' }}

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -43,9 +43,7 @@ jobs:
       run: |
           :
           timestamp=$(git log --no-walk --date=unix --format=%cd $GITHUB_SHA)
-          echo $GITHUB_SHA
           days=$(( ( $(date --utc +%s) - $timestamp ) / 86400 ))
-          echo $days
           if [ $days -eq 0 ]; then
               echo COMMIT_TODAY=true >> $GITHUB_ENV
           fi

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -26,7 +26,7 @@ on:
 jobs:
   build-and-publish:
     # do not run in forks
-    # if: ${{ github.repository_owner == 'oap-project' }}
+    if: ${{ github.repository_owner == 'oap-project' }}
     name: build wheel and upload
     runs-on: ubuntu-latest
     steps:
@@ -47,17 +47,15 @@ jobs:
           days=$(( ( $(date --utc +%s) - $timestamp ) / 86400 ))
           echo $days
           if [ $days -eq 0 ]; then
-              echo COMMIT_SINCE_LAST_UPLOAD=true >> $GITHUB_ENV
+              echo COMMIT_TODAY=true >> $GITHUB_ENV
           fi
     - name: Build wheel
-      if: env.COMMIT_SINCE_LAST_UPLOAD == 'true'
+      if: env.COMMIT_TODAY == 'true'
       env:
         RAYDP_PACKAGE_NAME: raydp_nightly
       run: pip install wheel && ./build.sh
     - name: Upload
-      if: env.COMMIT_SINCE_LAST_UPLOAD == 'true'
+      if: env.COMMIT_TODAY == 'true'
       uses: pypa/gh-action-pypi-publish@master
       with:
-        # password: ${{ secrets.PYPI_API_TOKEN }}
-        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-        repository_url: https://test.pypi.org/legacy/
+        password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Use the timestamp of the commit on which the workflow is run, and see if it is within 24 hrs. If it is, then we go ahead and upload. Otherwise, we should have already uploaded it in the last run, so do nothing. 