### PR TITLE
bump spark version

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -64,7 +64,7 @@ try:
         "psutil",
         "pyarrow >= 0.10",
         "ray >= 1.1.0",
-        "pyspark >= 3.0.0, < 3.1.0"
+        "pyspark >= 3.0.0"
     ]
 
     _packages = find_packages()


### PR DESCRIPTION
raydp is compatible with the latest spark version, so remove the limit.