### PR TITLE
Revert "bump spark version"

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -64,7 +64,7 @@ try:
         "psutil",
         "pyarrow >= 0.10",
         "ray >= 1.1.0",
-        "pyspark >= 3.0.0"
+        "pyspark >= 3.0.0, < 3.1.0"
     ]
 
     _packages = find_packages()


### PR DESCRIPTION
Due to issue #121 , pyspark is restricted to 3.0.0 for now.
Reverts oap-project/raydp#113