### PR TITLE
use ray java snapshot version

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -21,7 +21,7 @@
     <fasterxml.jackson.version>2.12.2</fasterxml.jackson.version>
     <jersey.version>2.31</jersey.version>
     <scala.binary.version>2.12</scala.binary.version>
-    <ray.version>1.2.0</ray.version>
+    <ray.version>1.1.0-SNAPSHOT</ray.version>
   </properties>
 
   <repositories>

--- a/core/src/main/java/org/apache/spark/raydp/AppMasterJavaUtils.java
+++ b/core/src/main/java/org/apache/spark/raydp/AppMasterJavaUtils.java
@@ -25,13 +25,12 @@ import java.util.Arrays;
 import org.apache.spark.executor.RayCoarseGrainedExecutorBackend;
 
 public class AppMasterJavaUtils {
-  private static int MEMORY_RESOURCE_UNIT_BYTES = 50 * 1024 * 1024;
   /**
-   * Convert from mbs -> memory units. The memory units in ray is 50 * 1024 * 1024
+   * Convert from mbs -> memory units. The memory units in ray is byte
    */
    
   private static double toMemoryUnits(int memoryInMB) {
-    double result = 1.0 * memoryInMB * 1024 * 1024 / MEMORY_RESOURCE_UNIT_BYTES;
+    double result = 1.0 * memoryInMB * 1024 * 1024;
     return Math.round(result);
   }
 

--- a/core/src/main/java/org/apache/spark/raydp/AppMasterJavaUtils.java
+++ b/core/src/main/java/org/apache/spark/raydp/AppMasterJavaUtils.java
@@ -21,6 +21,7 @@ import io.ray.api.ActorHandle;
 import io.ray.api.Ray;
 import io.ray.api.call.ActorCreator;
 import java.util.Map;
+import java.util.Arrays;
 import org.apache.spark.executor.RayCoarseGrainedExecutorBackend;
 
 public class AppMasterJavaUtils {
@@ -44,7 +45,7 @@ public class AppMasterJavaUtils {
     ActorCreator<RayCoarseGrainedExecutorBackend> creator = Ray.actor(
             RayCoarseGrainedExecutorBackend::new, executorId, appMasterURL);
 
-    creator.setJvmOptions(javaOpts);
+    creator.setJvmOptions(Arrays.asList(javaOpts.split(" ")));
     creator.setResource("CPU", (double)cores);
     creator.setResource("memory", toMemoryUnits(memoryInMB));
     for (Map.Entry<String, Double> entry: resources.entrySet()) {


### PR DESCRIPTION
This PR creates a new branch to be compatible with Ray nightly, 2.0.0-dev. The ray jar version is still 1.1.0-SNAPSHOT because they didn't update the version for long, but it's actually 2.0.0-SNAPSHOT. I have submitted a PR there to update it.