### PR TITLE
Fix executor class path issue

### DIFF
--- a/core/src/main/scala/org/apache/spark/executor/RayCoarseGrainedExecutorBackend.scala
+++ b/core/src/main/scala/org/apache/spark/executor/RayCoarseGrainedExecutorBackend.scala
@@ -88,7 +88,8 @@ class RayCoarseGrainedExecutorBackend(
     setUserDir()
     redirectLog()
 
-    val userClassPath = classPathEntries.split(java.io.File.pathSeparator).filter(_.nonEmpty).map(new File(_).toURI.toURL)
+    val userClassPath = classPathEntries.split(java.io.File.pathSeparator)
+      .filter(_.nonEmpty).map(new File(_).toURI.toURL)
     val createFn: (RpcEnv, SparkEnv, ResourceProfile) =>
       CoarseGrainedExecutorBackend = {
       case (rpcEnv, env, resourceProfile) =>

--- a/core/src/main/scala/org/apache/spark/executor/RayCoarseGrainedExecutorBackend.scala
+++ b/core/src/main/scala/org/apache/spark/executor/RayCoarseGrainedExecutorBackend.scala
@@ -88,7 +88,7 @@ class RayCoarseGrainedExecutorBackend(
     setUserDir()
     redirectLog()
 
-    val userClassPath = classPathEntries.split(";").filter(_.nonEmpty).map(new URL(_))
+    val userClassPath = classPathEntries.split(java.io.File.pathSeparator).filter(_.nonEmpty).map(new File(_).toURI.toURL)
     val createFn: (RpcEnv, SparkEnv, ResourceProfile) =>
       CoarseGrainedExecutorBackend = {
       case (rpcEnv, env, resourceProfile) =>


### PR DESCRIPTION
The executor class path is not decoded correctly it should use `:` as a separator
(Also resolving to URL fails)