### PR TITLE
fix #148 enable external shuffle service when using raydp-submit

### DIFF
--- a/core/src/main/java/org/apache/spark/deploy/ExternalShuffleServiceUtils.java
+++ b/core/src/main/java/org/apache/spark/deploy/ExternalShuffleServiceUtils.java
@@ -22,9 +22,10 @@ import io.ray.api.Ray;
 
 public class ExternalShuffleServiceUtils {
   public static ActorHandle<RayExternalShuffleService> createShuffleService(
-      String node) {
+      String node, String options) {
     return Ray.actor(RayExternalShuffleService::new)
-              .setResource("node:" + node, 0.01).remote();
+              .setResource("node:" + node, 0.01)
+              .setJvmOptions(options).remote();
   }
 
   public static void startShuffleService(

--- a/core/src/main/java/org/apache/spark/deploy/RayAppMasterUtils.java
+++ b/core/src/main/java/org/apache/spark/deploy/RayAppMasterUtils.java
@@ -21,8 +21,9 @@ import io.ray.api.ActorHandle;
 import io.ray.api.Ray;
 
 public class RayAppMasterUtils {
-  public static ActorHandle<RayAppMaster> createAppMaster(String cp) {
-    return Ray.actor(RayAppMaster::new, cp).remote();
+  public static ActorHandle<RayAppMaster> createAppMaster(
+      String cp, String jvmOptions) {
+    return Ray.actor(RayAppMaster::new, cp).setJvmOptions(jvmOptions).remote();
   }
 
   public static String getMasterUrl(

--- a/core/src/main/scala/org/apache/spark/deploy/raydp/RayAppMaster.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/raydp/RayAppMaster.scala
@@ -105,6 +105,7 @@ class RayAppMaster(host: String,
                   = new HashMap[String, ActorHandle[RayExternalShuffleService]]()
 
     private var nextAppNumber = 0
+    private val shuffleServiceOptions = RayExternalShuffleService.getShuffleConf(conf)
 
     override def receive: PartialFunction[Any, Unit] = {
       case RegisterApplication(appDescription: ApplicationDescription, driver: RpcEndpointRef) =>
@@ -133,7 +134,8 @@ class RayAppMaster(host: String,
             // the node executor is in has not started shuffle service
             if (!nodesWithShuffleService.contains(executorIp)) {
               logInfo(s"Starting shuffle service on ${executorIp}")
-              val service = ExternalShuffleServiceUtils.createShuffleService(executorIp)
+              val service = ExternalShuffleServiceUtils.createShuffleService(
+                executorIp, shuffleServiceOptions)
               ExternalShuffleServiceUtils.startShuffleService(service)
               nodesWithShuffleService(executorIp) = service
             }

--- a/core/src/main/scala/org/apache/spark/deploy/raydp/RayExternalShuffleService.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/raydp/RayExternalShuffleService.scala
@@ -37,3 +37,21 @@ class RayExternalShuffleService() extends Logging {
       Ray.exitActor()
   }
 }
+
+object RayExternalShuffleService {
+    def getShuffleConf(conf: SparkConf): String = {
+    // all conf needed by external shuffle service
+    var shuffleConf = conf.getAll.filter {
+      case (k, v) => k.startsWith("spark.shuffle")
+    }.map {
+      case (k, v) =>
+      "-D" + k + "=" + v
+    }
+    val localDirKey = "spark.local.dir"
+    if (conf.contains(localDirKey)) {
+      shuffleConf = shuffleConf :+
+        "-D" + localDirKey + "=" + conf.get(localDirKey)
+    }
+    shuffleConf.mkString(" ")
+  }
+}

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/raydp/RayCoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/raydp/RayCoarseGrainedSchedulerBackend.scala
@@ -66,7 +66,8 @@ class RayCoarseGrainedSchedulerBackend(
         // not yet started
         Ray.init()
         val cp = sys.props("java.class.path")
-        masterHandle = RayAppMasterUtils.createAppMaster(cp)
+        val options = RayExternalShuffleService.getShuffleConf(conf)
+        masterHandle = RayAppMasterUtils.createAppMaster(cp, options)
         uri = new URI(RayAppMasterUtils.getMasterUrl(masterHandle))
       } else {
         uri = new URI(sparkUrl)


### PR DESCRIPTION
Previously when using raydp-submit, RayAppMaster did not get the correct SparkConf, and so it cannot start external shuffle service. Also, spark conf related to shuffle should be passed to external shuffle service actors. This PR solves these problems.