### PR TITLE
limit ray to 1.3.0 in CI

### DIFF
--- a/.github/workflows/raydp.yml
+++ b/.github/workflows/raydp.yml
@@ -69,7 +69,7 @@ jobs:
           else
             pip install torch
           fi
-          pip install pytest koalas tensorflow tabulate ray[tune] xgboost_ray grpcio-tools
+          pip install pytest koalas tensorflow tabulate ray[tune]==1.3.0 xgboost_ray grpcio-tools
           HOROVOD_WITH_GLOO=1
           HOROVOD_WITH_PYTORCH=1
           pip install horovod[pytorch,ray]

--- a/python/setup.py
+++ b/python/setup.py
@@ -95,7 +95,7 @@ try:
         "pandas == 1.1.4",
         "psutil",
         "pyarrow >= 0.10",
-        "ray >= 1.3.0",
+        "ray == 1.3.0",
         "pyspark >= 3.0.0, < 3.1.0"
     ]
 


### PR DESCRIPTION
ray 1.4.0 has breaking change, but 1.4.0 jar is not deployed yet. So for now we limit ray to 1.3.0 in CI to pass tests