### PR TITLE
assign owner in from_spark so that spark executors can be killed

### DIFF
--- a/.github/workflows/raydp.yml
+++ b/.github/workflows/raydp.yml
@@ -70,32 +70,8 @@ jobs:
           SUBVERSION=$(python -c 'import sys; print(sys.version_info[1])')
           if [ "$(uname -s)" == "Linux" ]
           then
-            # install ray-nightly for linux
-            case $SUBVERSION in
-              6)
-                pip install -U https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-2.0.0.dev0-cp36-cp36m-manylinux2014_x86_64.whl
-                ;;
-              7)
-                pip install -U https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-2.0.0.dev0-cp37-cp37m-manylinux2014_x86_64.whl
-                ;;
-              8)
-                pip install -U https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-2.0.0.dev0-cp38-cp38-manylinux2014_x86_64.whl
-                ;;
-            esac
             pip install torch==1.8.1+cpu -f https://download.pytorch.org/whl/torch_stable.html
           else
-          # install ray-nightly for mac
-          case $SUBVERSION in
-            6)
-              pip install -U https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-2.0.0.dev0-cp36-cp36m-macosx_10_15_intel.whl
-              ;;
-            7)
-              pip install -U https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-2.0.0.dev0-cp37-cp37m-macosx_10_15_intel.whl
-              ;;
-            8)
-              pip install -U https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-2.0.0.dev0-cp38-cp38-macosx_10_15_x86_64.whl
-              ;;
-          esac
             pip install torch
           fi
           pip install pytest koalas tensorflow tabulate xgboost xgboost_ray grpcio-tools

--- a/.github/workflows/raydp.yml
+++ b/.github/workflows/raydp.yml
@@ -87,13 +87,13 @@ jobs:
           # install ray-nightly for mac
           case $SUBVERSION in
             6)
-              pip install -U https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-2.0.0.dev0-cp36-cp36m-macosx_10_13_intel.whl
+              pip install -U https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-2.0.0.dev0-cp36-cp36m-macosx_10_15_intel.whl
               ;;
             7)
-              pip install -U https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-2.0.0.dev0-cp37-cp37m-macosx_10_13_intel.whl
+              pip install -U https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-2.0.0.dev0-cp37-cp37m-macosx_10_15_intel.whl
               ;;
             8)
-              pip install -U https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-2.0.0.dev0-cp38-cp38-macosx_10_13_x86_64.whl
+              pip install -U https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-2.0.0.dev0-cp38-cp38-macosx_10_15_x86_64.whl
               ;;
           esac
             pip install torch

--- a/core/src/main/java/org/apache/spark/deploy/RayAppMasterUtils.java
+++ b/core/src/main/java/org/apache/spark/deploy/RayAppMasterUtils.java
@@ -20,6 +20,7 @@ package org.apache.spark.deploy.raydp;
 import java.util.List;
 
 import io.ray.api.ActorHandle;
+import io.ray.api.ObjectRef;
 import io.ray.api.Ray;
 
 public class RayAppMasterUtils {
@@ -37,5 +38,18 @@ public class RayAppMasterUtils {
       ActorHandle<RayAppMaster> handle) {
     handle.task(RayAppMaster::stop).remote().get();
     handle.kill();
+  }
+
+  public static String RAYDP_OWNER_NAME = "RAYDP_OBJECT_OWNER";
+
+  public static void createObjectOwner() {
+    Ray.actor(RayDPObjectOwner::new)
+        .setGlobalName(RAYDP_OWNER_NAME)
+        .remote();
+  }
+
+  public static void addObjectRef(ActorHandle<RayDPObjectOwner> owner,
+      ObjectRef<ObjectRef<byte[]>> ref) {
+    owner.task(RayDPObjectOwner::addObjectRef, ref).remote();
   }
 }

--- a/core/src/main/java/org/apache/spark/deploy/RayAppMasterUtils.java
+++ b/core/src/main/java/org/apache/spark/deploy/RayAppMasterUtils.java
@@ -42,8 +42,8 @@ public class RayAppMasterUtils {
 
   public static String RAYDP_OWNER_NAME = "RAYDP_OBJECT_OWNER";
 
-  public static void createObjectOwner() {
-    Ray.actor(RayDPObjectOwner::new)
+  public static ActorHandle<RayDPObjectOwner> createObjectOwner() {
+    return Ray.actor(RayDPObjectOwner::new)
         .setGlobalName(RAYDP_OWNER_NAME)
         .remote();
   }

--- a/core/src/main/scala/org/apache/spark/deploy/raydp/RayAppMaster.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/raydp/RayAppMaster.scala
@@ -66,6 +66,7 @@ class RayAppMaster(host: String,
       clientMode = false)
     // register endpoint
     endpoint = rpcEnv.setupEndpoint(RayAppMaster.ENDPOINT_NAME, new RayAppMasterEndpoint(rpcEnv))
+    RayAppMasterUtils.createObjectOwner()
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/deploy/raydp/RayAppMaster.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/raydp/RayAppMaster.scala
@@ -38,6 +38,7 @@ import org.apache.spark.util.Utils
 class RayAppMaster(host: String,
                    port: Int,
                    actor_extra_classpath: String) extends Serializable with Logging {
+  private var owner_handle: ActorHandle[RayDPObjectOwner] = _
   private var endpoint: RpcEndpointRef = _
   private var rpcEnv: RpcEnv = _
   private val conf: SparkConf = new SparkConf()
@@ -66,7 +67,7 @@ class RayAppMaster(host: String,
       clientMode = false)
     // register endpoint
     endpoint = rpcEnv.setupEndpoint(RayAppMaster.ENDPOINT_NAME, new RayAppMasterEndpoint(rpcEnv))
-    RayAppMasterUtils.createObjectOwner()
+    owner_handle = RayAppMasterUtils.createObjectOwner()
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/deploy/raydp/RayDPObjectOwner.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/raydp/RayDPObjectOwner.scala
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.deploy.raydp
+
+import io.ray.api.ObjectRef
+import scala.collection.mutable.Set
+
+class RayDPObjectOwner {
+  private val refHolder = Set.empty[ObjectRef[Array[Byte]]]
+  
+  def addObjectRef(ref: ObjectRef[Array[Byte]]): Unit = {
+    refHolder.add(ref)
+  }
+}
+
+object RayDPObjectOwner {
+  val RAYDP_OWNER_NAME: String = "raydp_object_owner"
+}

--- a/core/src/main/scala/org/apache/spark/deploy/raydp/RayDPObjectOwner.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/raydp/RayDPObjectOwner.scala
@@ -22,7 +22,7 @@ import scala.collection.mutable.Set
 
 class RayDPObjectOwner {
   private val refHolder = Set.empty[ObjectRef[Array[Byte]]]
-  
+
   def addObjectRef(ref: ObjectRef[Array[Byte]]): Unit = {
     refHolder.add(ref)
   }

--- a/core/src/main/scala/org/apache/spark/sql/raydp/ObjectStoreWriter.scala
+++ b/core/src/main/scala/org/apache/spark/sql/raydp/ObjectStoreWriter.scala
@@ -31,9 +31,8 @@ import io.ray.runtime.RayRuntimeInternal
 import org.apache.arrow.vector.VectorSchemaRoot
 import org.apache.arrow.vector.ipc.ArrowStreamWriter
 
+import org.apache.spark.deploy.raydp.{RayAppMasterUtils, RayDPObjectOwner}
 import org.apache.spark.raydp.RayDPUtils
-import org.apache.spark.deploy.raydp.RayAppMasterUtils
-import org.apache.spark.deploy.raydp.RayDPObjectOwner
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.execution.arrow.ArrowWriter
 import org.apache.spark.sql.execution.python.BatchIterator
@@ -83,7 +82,7 @@ class ObjectStoreWriter(@transient val df: DataFrame) extends Serializable {
     val schema = df.schema
 
     val objectIds = df.queryExecution.toRdd.mapPartitions{ iter =>
-      val owner: ActorHandle[RayDPObjectOwner] = 
+      val owner: ActorHandle[RayDPObjectOwner] =
           Ray.getGlobalActor(RayAppMasterUtils.RAYDP_OWNER_NAME).get
       // DO NOT use iter.grouped(). See BatchIterator.
       val batchIter = if (batchSize > 0) {

--- a/examples/xgboost_ray_nyctaxi.py
+++ b/examples/xgboost_ray_nyctaxi.py
@@ -30,6 +30,8 @@ train_df, test_df = random_split(data, [0.9, 0.1], 0)
 # Convert spark dataframe into ray dataset
 train_dataset = ray.data.from_spark(train_df)
 test_dataset = ray.data.from_spark(test_df)
+# can shutdown spark executors now
+raydp.stop_spark_session()
 # Then convert them into DMatrix used by xgboost
 dtrain = RayDMatrix(train_dataset, label='fare_amount')
 dtest = RayDMatrix(test_dataset, label='fare_amount')

--- a/python/raydp/__init__.py
+++ b/python/raydp/__init__.py
@@ -15,8 +15,8 @@
 # limitations under the License.
 #
 
-from raydp.context import init_spark, stop_spark
+from raydp.context import init_spark, stop_spark, stop_spark_session
 
 __version__ = "0.4.0.dev0"
 
-__all__ = ["init_spark", "stop_spark"]
+__all__ = ["init_spark", "stop_spark", "stop_spark_session"]

--- a/python/raydp/context.py
+++ b/python/raydp/context.py
@@ -74,13 +74,13 @@ class _SparkContext(ContextDecorator):
             self._configs)
         return self._spark_session
 
-    def stop_spark(self):
+    def stop_spark_session(self):
         if self._spark_session is not None:
             self._spark_session.stop()
             self._spark_session = None
 
-    def stop_all(self):
-        self.stop_spark()
+    def stop_spark(self):
+        self.stop_spark_session()
         if self._spark_cluster is not None:
             self._spark_cluster.stop()
             self._spark_cluster = None
@@ -133,17 +133,17 @@ def init_spark(app_name: str,
                             "call init_spark if needed.")
 
 
+def stop_spark_session():
+    with _spark_context_lock:
+        global _global_spark_context
+        if _global_spark_context is not None:
+            _global_spark_context.stop_spark_session()
+
 def stop_spark():
     with _spark_context_lock:
         global _global_spark_context
         if _global_spark_context is not None:
             _global_spark_context.stop_spark()
-
-def stop_all():
-    with _spark_context_lock:
-        global _global_spark_context
-        if _global_spark_context is not None:
-            _global_spark_context.stop_all()
             _global_spark_context = None
 
-atexit.register(stop_all)
+atexit.register(stop_spark)

--- a/python/raydp/tests/test_spark_cluster.py
+++ b/python/raydp/tests/test_spark_cluster.py
@@ -81,5 +81,17 @@ def test_ray_dataset_to_spark(spark_on_ray_small):
     rows = [r.value for r in df.take(5)]
     assert values == rows
 
+def test_stop_spark_session(ray_cluster):
+    spark = raydp.init_spark(app_name="test_stop_spark_session",
+                            num_executors=1,
+                            executor_cores=1,
+                            executor_memory="500MB")
+    df = spark.range(0, 5)
+    ds = ray.data.from_spark(df)
+    raydp.stop_spark_session()
+    values = [r["id"] for r in ds.take(5)]
+    assert values == [0, 1, 2, 3, 4]
+    raydp.stop_spark()
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
This PR is to utilize previously implemented assigning owner in ray.put in Java. The assigned owner is now in Java, ideally it could be a python actor but not possible now. Therefore, RayAppMaster cannot be killed as long as the objects are needed. I add a stop_all, and moves stopping RayAppMaster from stop_spark to it.

Now stop_spark only stop the spark session, and is mainly for sparing resources for following workloads. Instead, stop_all will stop both the spark session and our RayAppMaster, and would be automatically called when program exits.