### PR TITLE
Enable placement group

### DIFF
--- a/core/src/main/java/org/apache/spark/raydp/RayExecutorUtils.java
+++ b/core/src/main/java/org/apache/spark/raydp/RayExecutorUtils.java
@@ -22,6 +22,8 @@ import io.ray.api.Ray;
 import io.ray.api.call.ActorCreator;
 import java.util.Map;
 import java.util.List;
+
+import io.ray.api.placementgroup.PlacementGroup;
 import org.apache.spark.executor.RayCoarseGrainedExecutorBackend;
 
 public class RayExecutorUtils {
@@ -40,6 +42,8 @@ public class RayExecutorUtils {
       int cores,
       int memoryInMB,
       Map<String, Double> resources,
+      PlacementGroup placementGroup,
+      int bundleIndex,
       List<String> javaOpts) {
     ActorCreator<RayCoarseGrainedExecutorBackend> creator = Ray.actor(
             RayCoarseGrainedExecutorBackend::new, executorId, appMasterURL);
@@ -48,6 +52,9 @@ public class RayExecutorUtils {
     creator.setResource("memory", toMemoryUnits(memoryInMB));
     for (Map.Entry<String, Double> entry: resources.entrySet()) {
       creator.setResource(entry.getKey(), entry.getValue());
+    }
+    if (placementGroup != null) {
+      creator.setPlacementGroup(placementGroup, bundleIndex);
     }
 
     return creator.remote();

--- a/core/src/main/scala/org/apache/spark/deploy/raydp/RayAppMaster.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/raydp/RayAppMaster.scala
@@ -17,23 +17,24 @@
 
 package org.apache.spark.deploy.raydp
 
+import io.ray.api.id.PlacementGroupId
+
 import java.io.File
 import java.text.SimpleDateFormat
-import java.util.{Date, Locale}
-
+import java.util.{Date, Locale, Optional}
 import scala.collection.JavaConverters._
 import scala.collection.mutable.HashMap
-
-import io.ray.api.ActorHandle
-import io.ray.api.Ray
+import io.ray.api.{ActorHandle, PlacementGroups, Ray}
+import io.ray.api.placementgroup.PlacementGroup
 import io.ray.runtime.config.RayConfig
-
 import org.apache.spark.{RayDPException, SecurityManager, SparkConf}
 import org.apache.spark.internal.Logging
 import org.apache.spark.raydp.RayExecutorUtils
 import org.apache.spark.rpc._
 import org.apache.spark.util.ShutdownHookManager
 import org.apache.spark.util.Utils
+
+import javax.xml.bind.DatatypeConverter
 
 class RayAppMaster(host: String,
                    port: Int,
@@ -106,6 +107,15 @@ class RayAppMaster(host: String,
 
     private var nextAppNumber = 0
     private val shuffleServiceOptions = RayExternalShuffleService.getShuffleConf(conf)
+
+    private val placementGroup: PlacementGroup = conf.getOption("spark.ray.placement_group").map { hex =>
+      val id = PlacementGroupId.fromBytes(DatatypeConverter.parseHexBinary(hex))
+      PlacementGroups.getPlacementGroup(id)
+    }.orNull
+    private val bundleIndexes: List[Int] = conf.getOption("spark.ray.bundle_indexes")
+      .map(_.split(",").map(_.toInt).toList)
+      .getOrElse(List.empty)
+    private var currentBundleIndex: Int = 0
 
     override def receive: PartialFunction[Any, Unit] = {
       case RegisterApplication(appDescription: ApplicationDescription, driver: RpcEndpointRef) =>
@@ -223,6 +233,8 @@ class RayAppMaster(host: String,
         executorId, getAppMasterEndpointUrl(), cores,
         memory,
         appInfo.desc.resourceReqsPerExecutor.map(pair => (pair._1, Double.box(pair._2))).asJava,
+        placementGroup,
+        getNextBundleIndex,
         seqAsJavaList(appInfo.desc.command.javaOpts))
       appInfo.addPendingRegisterExecutor(executorId, handler, cores, memory)
     }
@@ -261,6 +273,14 @@ class RayAppMaster(host: String,
       val appId = appInfo.id
       val classPathEntries = appInfo.desc.command.classPathEntries.mkString(";")
       RayExecutorUtils.setUpExecutor(handlerOpt.get, appId, driverUrl, cores, classPathEntries)
+    }
+
+    private def getNextBundleIndex: Int = {
+      if (placementGroup != null && bundleIndexes.nonEmpty) {
+        val previous = currentBundleIndex
+        currentBundleIndex = (currentBundleIndex + 1) % bundleIndexes.size
+        previous
+      } else -1
     }
   }
 }

--- a/core/src/main/scala/org/apache/spark/deploy/raydp/RayAppMaster.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/raydp/RayAppMaster.scala
@@ -17,24 +17,25 @@
 
 package org.apache.spark.deploy.raydp
 
-import io.ray.api.id.PlacementGroupId
-
 import java.io.File
 import java.text.SimpleDateFormat
 import java.util.{Date, Locale, Optional}
+import javax.xml.bind.DatatypeConverter
+
 import scala.collection.JavaConverters._
 import scala.collection.mutable.HashMap
+
 import io.ray.api.{ActorHandle, PlacementGroups, Ray}
+import io.ray.api.id.PlacementGroupId
 import io.ray.api.placementgroup.PlacementGroup
 import io.ray.runtime.config.RayConfig
+
 import org.apache.spark.{RayDPException, SecurityManager, SparkConf}
 import org.apache.spark.internal.Logging
 import org.apache.spark.raydp.RayExecutorUtils
 import org.apache.spark.rpc._
 import org.apache.spark.util.ShutdownHookManager
 import org.apache.spark.util.Utils
-
-import javax.xml.bind.DatatypeConverter
 
 class RayAppMaster(host: String,
                    port: Int,
@@ -108,10 +109,12 @@ class RayAppMaster(host: String,
     private var nextAppNumber = 0
     private val shuffleServiceOptions = RayExternalShuffleService.getShuffleConf(conf)
 
-    private val placementGroup: PlacementGroup = conf.getOption("spark.ray.placement_group").map { hex =>
-      val id = PlacementGroupId.fromBytes(DatatypeConverter.parseHexBinary(hex))
-      PlacementGroups.getPlacementGroup(id)
-    }.orNull
+    private val placementGroup: PlacementGroup = conf
+      .getOption("spark.ray.placement_group")
+      .map { hex =>
+        val id = PlacementGroupId.fromBytes(DatatypeConverter.parseHexBinary(hex))
+        PlacementGroups.getPlacementGroup(id)
+      }.orNull
     private val bundleIndexes: List[Int] = conf.getOption("spark.ray.bundle_indexes")
       .map(_.split(",").map(_.toInt).toList)
       .getOrElse(List.empty)

--- a/core/src/main/scala/org/apache/spark/deploy/raydp/RayAppMaster.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/raydp/RayAppMaster.scala
@@ -283,7 +283,9 @@ class RayAppMaster(host: String,
         val previous = currentBundleIndex
         currentBundleIndex = (currentBundleIndex + 1) % bundleIndexes.size
         previous
-      } else -1
+      } else {
+        -1
+      }
     }
   }
 }

--- a/doc/spark_on_ray.md
+++ b/doc/spark_on_ray.md
@@ -18,3 +18,16 @@ ds = RayMLDataset.from_spark(..., fs_directory="hdfs://host:port/your/directory"
 ### Spark Submit
 
 RayDP provides a substitute for spark-submit in Apache Spark. You can run your java or scala application on RayDP cluster by using `bin/raydp-submit`. You can add it to `PATH` for convenience. When using `raydp-submit`, you should specify number of executors, number of cores and memory each executor by Spark properties, such as `--conf spark.executor.cores=1`, `--conf spark.executor.instances=1` and `--conf spark.executor.memory=500m`. `raydp-submit` only supports Ray cluster. Spark standalone, Apache Mesos, Apache Yarn are not supported, please use traditional `spark-submit` in that case. For the same reason, you do not need to specify `--master` in the command. Besides, RayDP does not support cluster as deploy-mode.
+
+### Placement Group
+RayDP can leverage Ray's placement group feature and schedule executors onto spcecified placement group. It provides better control over the allocation of Spark executors on a Ray cluster, for example spreading the spark executors onto seperate nodes or starting all executors on a single node. You can specify a created placement group when init spark, as shown below:
+
+```python
+raydp.init_spark(..., placement_group=pg)
+```
+
+Or you can just specify the placement group strategy. RayDP will create a coreesponding placement group and manage its lifecycle, which means the placement group will be created together with SparkSession and removed when calling `raydp.stop_spark()`. Strategy can be "PACK", "SPREAD", "STRICT_PACK" or "STRICT_SPREAD". Please refer to [Placement Groups document](https://docs.ray.io/en/latest/placement-group.html#pgroup-strategy) for details.
+
+```python
+raydp.init_spark(..., placement_group_strategy="SPREAD")
+```

--- a/python/raydp/context.py
+++ b/python/raydp/context.py
@@ -89,7 +89,8 @@ class _SparkContext(ContextDecorator):
         if self._placement_group_strategy is not None:
             bundles = []
             for _ in range(self._num_executors):
-                bundles.append({"CPU": self._executor_cores})
+                bundles.append({"CPU": self._executor_cores,
+                                "memory": self._executor_memory})
             pg = ray.util.placement_group(bundles, strategy=self._placement_group_strategy)
             ray.get(pg.ready())
             self._placement_group = pg

--- a/python/raydp/spark/ray_cluster_master.py
+++ b/python/raydp/spark/ray_cluster_master.py
@@ -80,7 +80,12 @@ class RayClusterMaster(ClusterMaster):
             stdout/stderr).
         """
 
+        env = dict(os.environ)
+
         command = ["java"]
+        java_opts = env["JAVA_OPTS"]
+        if java_opts is not None:
+            command.append(java_opts)
         command.append("-cp")
         command.append(class_path)
         command.append("org.apache.spark.deploy.raydp.AppMasterEntryPoint")
@@ -93,7 +98,6 @@ class RayClusterMaster(ClusterMaster):
             os.close(fd)
             os.unlink(conn_info_file)
 
-            env = dict(os.environ)
             env["_RAYDP_APPMASTER_CONN_INFO_PATH"] = conn_info_file
 
             # Launch the Java gateway.

--- a/python/raydp/spark/ray_cluster_master.py
+++ b/python/raydp/spark/ray_cluster_master.py
@@ -83,9 +83,10 @@ class RayClusterMaster(ClusterMaster):
         env = dict(os.environ)
 
         command = ["java"]
-        java_opts = env["JAVA_OPTS"]
-        if java_opts is not None:
-            command.append(java_opts)
+
+        # append JAVA_OPTS. This can be used for debugging.
+        if "JAVA_OPTS" in env:
+            command.append(env["JAVA_OPTS"])
         command.append("-cp")
         command.append(class_path)
         command.append("org.apache.spark.deploy.raydp.AppMasterEntryPoint")

--- a/python/raydp/tests/test_spark_cluster.py
+++ b/python/raydp/tests/test_spark_cluster.py
@@ -94,24 +94,37 @@ def test_ray_dataset_to_spark(spark_on_ray_small):
 
 
 def test_placement_group(ray_cluster):
-    spark = raydp.init_spark("test_strategy", 1, 1, "500 M",
-                             placement_group_strategy="SPREAD")
-    result = spark.range(0, 10, numPartitions=1).count()
-    assert result == 10
-    raydp.stop_spark()
+    for pg_strategy in ["PACK", "STRICT_PACK", "SPREAD", "STRICT_SPREAD"]:
+        spark = raydp.init_spark("test_strategy", 1, 1, "500 M",
+                                 placement_group_strategy=pg_strategy)
+        result = spark.range(0, 10, numPartitions=10).count()
+        assert result == 10
+        raydp.stop_spark()
 
-    time.sleep(3)
+        time.sleep(3)
 
-    pg = ray.util.placement_group([{"CPU": 1, "memory": utils.parse_memory_size("500 M")}],
-                                  strategy="STRICT_PACK")
-    ray.get(pg.ready())
-    spark = raydp.init_spark("test_bundle", 1, 1, "500 M",
-                             placement_group=pg,
-                             placement_group_bundle_indexes=[0])
-    result = spark.range(0, 10, numPartitions=1).count()
-    assert result == 10
-    raydp.stop_spark()
-    ray.util.remove_placement_group(pg)
+        # w/ existing placement group w/ bundle indexes
+        pg = ray.util.placement_group([{"CPU": 1, "memory": utils.parse_memory_size("500 M")}],
+                                      strategy=pg_strategy)
+        ray.get(pg.ready())
+        spark = raydp.init_spark("test_bundle", 1, 1, "500 M",
+                                 placement_group=pg,
+                                 placement_group_bundle_indexes=[0])
+        result = spark.range(0, 10, numPartitions=10).count()
+        assert result == 10
+        raydp.stop_spark()
+
+        time.sleep(3)
+
+        # w/ existing placement group w/o bundle indexes
+        spark = raydp.init_spark("test_bundle", 1, 1, "500 M",
+                                 placement_group=pg)
+        result = spark.range(0, 10, numPartitions=10).count()
+        assert result == 10
+        raydp.stop_spark()
+        ray.util.remove_placement_group(pg)
+
+        time.sleep(3)
 
     num_non_removed_pgs = len([
         p for pid, p in placement_group_table().items()

--- a/python/raydp/tests/test_spark_cluster.py
+++ b/python/raydp/tests/test_spark_cluster.py
@@ -93,7 +93,8 @@ def test_ray_dataset_to_spark(spark_on_ray_small):
 
 
 def test_placement_group(ray_cluster):
-    raydp.init_spark("test_single_bundle", 1, 1, "500 M", "SPREAD")
+    raydp.init_spark("test_strategy", 1, 1, "500 M",
+                     placement_group_strategy="SPREAD")
     raydp.stop_spark()
 
     time.sleep(3)

--- a/python/raydp/tests/test_spark_cluster.py
+++ b/python/raydp/tests/test_spark_cluster.py
@@ -16,10 +16,13 @@
 #
 
 import sys
+import time
 
 import pytest
 import ray
 import ray._private.services
+
+from ray.util.placement_group import placement_group_table
 
 import raydp
 
@@ -61,6 +64,7 @@ def test_spark_driver_and_executor_hostname(spark_on_ray_small):
     driver_bind_address = conf.get("spark.driver.bindAddress")
     assert node_ip_address == driver_bind_address
 
+
 def test_ray_dataset_roundtrip(spark_on_ray_small):
     spark = spark_on_ray_small
     spark_df = spark.createDataFrame([(1, "a"), (2, "b"), (3, "c")], ["one", "two"])
@@ -71,6 +75,7 @@ def test_ray_dataset_roundtrip(spark_on_ray_small):
     df = ds.to_spark(spark)
     rows_2 = [(r.one, r.two) for r in df.take(3)]
     assert values == rows_2
+
 
 def test_ray_dataset_to_spark(spark_on_ray_small):
     spark = spark_on_ray_small
@@ -85,6 +90,28 @@ def test_ray_dataset_to_spark(spark_on_ray_small):
     df2 = ds2.to_spark(spark)
     rows2 = [r.id for r in df2.take(n)]
     assert ids == rows2
+
+
+def test_placement_group(ray_cluster):
+    raydp.init_spark("test_single_bundle", 1, 1, "500 M", "SPREAD")
+    raydp.stop_spark()
+
+    time.sleep(3)
+
+    pg = ray.util.placement_group([{"CPU": 1}], strategy="STRICT_PACK")
+    ray.get(pg.ready())
+    raydp.init_spark("test_bundle", 1, 1, "500 M",
+                     placement_group=pg,
+                     placement_group_bundle_indexes=[0])
+    raydp.stop_spark()
+    ray.util.remove_placement_group(pg)
+
+    num_non_removed_pgs = len([
+        p for pid, p in placement_group_table().items()
+        if p["state"] != "REMOVED"
+    ])
+    assert num_non_removed_pgs == 0
+
 
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
For now, there are two ways of using placement group.
1. Specify a placement group strategy. It will create a placement group according to the strategy and the configured resources for executors. The placement group will be removed when spark session stops.
2. Specify the placement group to use, and a list of bundle indexes. If no bundle indexes is specified, all bundles will be used.

issue: https://github.com/oap-project/raydp/issues/81