### PR TITLE
expose the executor java worker classpath parameter to user

### DIFF
--- a/doc/spark_on_ray.md
+++ b/doc/spark_on_ray.md
@@ -15,6 +15,16 @@ Similarly, you can also enable Dynamic Executor Allocation this way. However, cu
 ds = RayMLDataset.from_spark(..., fs_directory="hdfs://host:port/your/directory")
 ```
 
+### RayDP Executor Extra ClassPath 
+
+As raydp starts the java executors, the classpath will contain the absolute path of ray, raydp and spark by default. When you run ray cluster on yarn([Deploying on Yarn](https://docs.ray.io/en/latest/cluster/yarn.html)), the jar files are stored on HDFS, which have different absolute path in each node. In such cases,  jvm cannot find the main class and ray workers will fail to start. 
+
+To solve such problems, users can specify extra classpath when` init _spark` by configuring `raydp.executor.extraClassPath`. Make sure your jar files are distributed to the same path(s) on all nodes of the ray cluster.
+
+```python
+raydp.init_spark(..., configs={"raydp.executor.extraClassPath": "/your/extra/jar/path"})
+```
+
 ### Spark Submit
 
 RayDP provides a substitute for spark-submit in Apache Spark. You can run your java or scala application on RayDP cluster by using `bin/raydp-submit`. You can add it to `PATH` for convenience. When using `raydp-submit`, you should specify number of executors, number of cores and memory each executor by Spark properties, such as `--conf spark.executor.cores=1`, `--conf spark.executor.instances=1` and `--conf spark.executor.memory=500m`. `raydp-submit` only supports Ray cluster. Spark standalone, Apache Mesos, Apache Yarn are not supported, please use traditional `spark-submit` in that case. For the same reason, you do not need to specify `--master` in the command. Besides, RayDP does not support cluster as deploy-mode.

--- a/python/raydp/spark/ray_cluster_master.py
+++ b/python/raydp/spark/ray_cluster_master.py
@@ -60,6 +60,10 @@ class RayClusterMaster(ClusterMaster):
 
     def _prepare_jvm_classpath(self):
         cp_list = []
+
+        if "raydp.executor.extraClassPath" in self._configs:
+            cp_list.append(self._configs["raydp.executor.extraClassPath"])
+
         # find RayDP core path
         cp_list.append(RAYDP_CP)
         # find ray jar path


### PR DESCRIPTION
[ISSUE#199](https://github.com/oap-project/raydp/issues/199)

As for the discused in issue 199, when run ray cluster on yarn, the absolute path of the jars in each node is different, that would cause the executor started failed. Exposed the parameter will help.