### PR TITLE
make raydp work with the latest Ray

### DIFF
--- a/examples/horovod_nyctaxi.py
+++ b/examples/horovod_nyctaxi.py
@@ -126,7 +126,7 @@ if __name__ == '__main__':
     # Start horovod workers on Ray
     from horovod.ray import RayExecutor
     settings = RayExecutor.create_settings(500)
-    executor = RayExecutor(settings, num_hosts=1, num_slots=1, cpus_per_slot=1)
+    executor = RayExecutor(settings, num_workers=1, cpus_per_worker=1)
     executor.start()
     executor.run(train_fn, args=[torch_ds, num_features])
     raydp.stop_spark()

--- a/python/raydp/spark/ray_cluster_master.py
+++ b/python/raydp/spark/ray_cluster_master.py
@@ -152,6 +152,8 @@ class RayClusterMaster(ClusterMaster):
 
         options["ray.run-mode"] = "CLUSTER"
         options["ray.node-ip"] = node.node_ip_address
+        options["ray.address"] = node.address
+        options["ray.redis.password"] = node.redis_password
         options["ray.logging.dir"] = node.get_logs_dir_path()
         options["ray.session-dir"] = node.get_session_dir_path()
         options["ray.raylet.node-manager-port"] = node.node_manager_port
@@ -160,13 +162,6 @@ class RayClusterMaster(ClusterMaster):
         options["ray.object-store.socket-name"] = node.plasma_store_socket_name
         options["ray.logging.level"] = "INFO"
         options["ray.job.namespace"] = ray.get_runtime_context().namespace
-        if not self.get_gcs_status():
-            assert node.redis_address is not None
-            options["ray.address"] = node.redis_address
-            options["ray.redis.password"] = node.redis_password
-        else:
-            assert node.address is not None
-            options["ray.address"] = node.address
 
         # jnius_config.set_option has some bug, we set this options in java side
         jvm_properties = json.dumps(options)
@@ -199,9 +194,3 @@ class RayClusterMaster(ClusterMaster):
             self._gateway = None
 
         self._started_up = False
-
-    def get_gcs_status(self):
-        try:
-            return ray._private.gcs_utils.use_gcs_for_bootstrap()
-        except:
-            return False


### PR DESCRIPTION
The latest Ray does not enable redis by default, but uses gcs bootstrap mode. So gcs_address is used to set "ray.address", and the code takes into account the previous version.