### PR TITLE
migrate TorchEstimator to use Ray Train API and Ray Dataset

### DIFF
--- a/examples/pytorch_nyctaxi.py
+++ b/examples/pytorch_nyctaxi.py
@@ -50,7 +50,8 @@ class NYC_Model(nn.Module):
         self.bn3 = nn.BatchNorm1d(64)
         self.bn4 = nn.BatchNorm1d(16)
 
-    def forward(self, x):
+    def forward(self, *x):
+        x = torch.cat(x, dim=1)
         x = F.relu(self.fc1(x))
         x = self.bn1(x)
         x = F.relu(self.fc2(x))

--- a/examples/pytorch_nyctaxi.py
+++ b/examples/pytorch_nyctaxi.py
@@ -8,6 +8,8 @@ from raydp.torch import TorchEstimator
 from raydp.utils import random_split
 
 from data_process import nyc_taxi_preprocess, NYC_TRAIN_CSV
+from ray.train import TrainingCallback
+from typing import List, Dict
 
 # Firstly, You need to init or connect to a ray cluster. Note that you should set include_java to True.
 # For more config info in ray, please refer the ray doc. https://docs.ray.io/en/latest/package-ref.html
@@ -64,6 +66,10 @@ class NYC_Model(nn.Module):
         
         return x
 
+class PrintingCallback(TrainingCallback):
+    def handle_result(self, results: List[Dict], **info):
+        print(results)
+
 nyc_model = NYC_Model(len(features))
 criterion = nn.SmoothL1Loss()
 optimizer = torch.optim.Adam(nyc_model.parameters(), lr=0.001)
@@ -71,7 +77,7 @@ optimizer = torch.optim.Adam(nyc_model.parameters(), lr=0.001)
 estimator = TorchEstimator(num_workers=1, model=nyc_model, optimizer=optimizer, loss=criterion,
                            feature_columns=features, feature_types=torch.float,
                            label_column="fare_amount", label_type=torch.float,
-                           batch_size=64, num_epochs=30)
+                           batch_size=64, num_epochs=30, callbacks=[PrintingCallback()])
 # Train the model
 estimator.fit_on_spark(train_df, test_df)
 # shutdown raydp and ray

--- a/examples/pytorch_nyctaxi.py
+++ b/examples/pytorch_nyctaxi.py
@@ -3,13 +3,12 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-import sys
-sys.path.append('/home/rainbow/Documents/pr-project/raydp/python/raydp')
 import raydp
 from raydp.torch import TorchEstimator
 from raydp.utils import random_split
 
 from data_process import nyc_taxi_preprocess, NYC_TRAIN_CSV
+
 # Firstly, You need to init or connect to a ray cluster. Note that you should set include_java to True.
 # For more config info in ray, please refer the ray doc. https://docs.ray.io/en/latest/package-ref.html
 # ray.init(address="auto")

--- a/python/raydp/tests/test_torch.py
+++ b/python/raydp/tests/test_torch.py
@@ -67,7 +67,9 @@ def test_torch_estimator(spark_on_ray_small):
                                loss=loss,
                                lr_scheduler_creator=lr_scheduler_creator,
                                feature_columns=["x", "y"],
+                               feature_types=torch.float,
                                label_column="z",
+                               label_type=torch.float,
                                batch_size=1000,
                                num_epochs=2,
                                use_gpu=False)

--- a/python/raydp/tests/test_torch_sequential.py
+++ b/python/raydp/tests/test_torch_sequential.py
@@ -46,8 +46,10 @@ def test_torch_estimator(spark_on_ray_small):
         num_workers = 3,
         num_epochs = 5,
         feature_columns = ["age"],
-        label_column = ["grade"],
-        batch_size=2
+        feature_types = torch.float,
+        label_column = "grade",
+        label_type = torch.float,
+        batch_size = 2
     )
     estimator.fit_on_spark(df)
 

--- a/python/raydp/tests/test_torch_sequential.py
+++ b/python/raydp/tests/test_torch_sequential.py
@@ -49,7 +49,7 @@ def test_torch_estimator(spark_on_ray_small):
         feature_types = torch.float,
         label_column = "grade",
         label_type = torch.float,
-        batch_size = 2
+        batch_size = 1
     )
     estimator.fit_on_spark(df)
 

--- a/python/raydp/torch/estimator.py
+++ b/python/raydp/torch/estimator.py
@@ -107,7 +107,7 @@ class TorchEstimator(EstimatorInterface, SparkEstimatorInterface):
         :param drop_last: Set to True to drop the last incomplete batch
         :param num_epochs: the total number of epochs will be train
         :param num_processes_for_data_loader: the number of processes use to speed up data loading
-        :param callbacks: which will be executed during training. 
+        :param callbacks: which will be executed during training.
         :param extra_config: the extra config will be set to ray.train.Trainer
         """
         self._num_workers = num_workers
@@ -194,7 +194,8 @@ class TorchEstimator(EstimatorInterface, SparkEstimatorInterface):
                                                 drop_last=config["drop_last"])
         if config["evaluate"]:
             evaluate_data_shard = get_dataset_shard("evaluate")
-            evaluate_dataset = evaluate_data_shard.to_torch(feature_columns=config["feature_columns"],
+            evaluate_dataset = evaluate_data_shard.to_torch(
+                                                    feature_columns=config["feature_columns"],
                                                     label_column=config["label_column"],
                                                     label_column_dtype=config["label_type"],
                                                     feature_column_dtypes=config["feature_types"],

--- a/python/raydp/torch/estimator.py
+++ b/python/raydp/torch/estimator.py
@@ -259,9 +259,9 @@ class TorchEstimator(EstimatorInterface, SparkEstimatorInterface):
                                 resources_per_worker=self._resources_per_worker,
                                 max_retries=max_retries, **self._extra_config)
 
-        config = {"num_workers": self._num_workers, "batch_size": self._batch_size,
-                  "model": self._model, "optimizer": self._optimizer,
-                  "loss": self._loss, "lr_scheduler_creator": self._lr_scheduler_creator,
+        config = {"num_workers": self._num_workers, "model": self._model,
+                  "optimizer": self._optimizer, "loss": self._loss,
+                  "lr_scheduler_creator": self._lr_scheduler_creator,
                   "feature_columns": self._feature_columns, "feature_types": self._feature_types,
                   "label_column": self._label_column, "label_type": self._label_type,
                   "batch_size": self._batch_size, "num_epochs": self._num_epochs,

--- a/python/raydp/torch/estimator.py
+++ b/python/raydp/torch/estimator.py
@@ -81,6 +81,7 @@ class TorchEstimator(EstimatorInterface, SparkEstimatorInterface):
                  drop_last: bool = False,
                  num_epochs: int = None,
                  num_processes_for_data_loader: int = 0,
+                 callbacks: Optional[List[TrainingCallback]] = None,
                  **extra_config):
         """
         :param num_workers: the number of workers to do the distributed training
@@ -106,6 +107,7 @@ class TorchEstimator(EstimatorInterface, SparkEstimatorInterface):
         :param drop_last: Set to True to drop the last incomplete batch
         :param num_epochs: the total number of epochs will be train
         :param num_processes_for_data_loader: the number of processes use to speed up data loading
+        :param callbacks: which will be executed during training. 
         :param extra_config: the extra config will be set to ray.train.Trainer
         """
         self._num_workers = num_workers
@@ -122,6 +124,7 @@ class TorchEstimator(EstimatorInterface, SparkEstimatorInterface):
         self._drop_last = drop_last
         self._num_epochs = num_epochs
         self._num_processes_for_data_loader = num_processes_for_data_loader
+        self._callbacks = callbacks
         self._extra_config = extra_config
 
         if self._num_processes_for_data_loader > 0:
@@ -278,7 +281,7 @@ class TorchEstimator(EstimatorInterface, SparkEstimatorInterface):
         self._trainer.start()
         results = self._trainer.run(
             TorchEstimator.train_fun, config=config,
-            callbacks=[PrintingCallback()],
+            callbacks=self._callbacks,
             dataset=dataset
         )
         return results

--- a/python/raydp/torch/estimator.py
+++ b/python/raydp/torch/estimator.py
@@ -88,7 +88,7 @@ class TorchEstimator(EstimatorInterface, SparkEstimatorInterface):
         """
         :param num_workers: the number of workers to do the distributed training
         :param resources_per_worker: the resources defined in this Dict will be reserved for
-               each worker. The ``CPU`` and ``GPU`` keys (case-sensitive) can be defined to 
+               each worker. The ``CPU`` and ``GPU`` keys (case-sensitive) can be defined to
                override the number of CPU/GPUs used by each worker.
         :param model: the torch model instance or a function(dict -> Models) to create a model
         :param optimizer: the optimizer instance or a function((models, dict) -> optimizer) to

--- a/python/raydp/torch/estimator.py
+++ b/python/raydp/torch/estimator.py
@@ -99,7 +99,8 @@ def train_fun(config):
                                                             optimizer, lr_scheduler)
         train.report(epoch=epoch, train_acc=train_acc, train_loss=train_loss)
         if config["evaluate"]:
-            evaluate_acc, evaluate_loss = TorchEstimator.evaluate_epoch(evaluate_dataset, model, loss)
+            evaluate_acc, evaluate_loss = TorchEstimator.evaluate_epoch(evaluate_dataset,
+                                                                        model, loss)
             train.report(epoch=epoch, evaluate_acc=evaluate_acc, test_loss=evaluate_loss)
             loss_results.append(evaluate_loss)
 


### PR DESCRIPTION
**Parameters change details:**
- \+ resources_per_worker: used in Trainer. The resources reserved for each worker.
- \+ drop_last: used in RayDataset.to_torch(). Determine whether to drop the last incomplete batch.
- \+ callbacks: used in Trainer.run(). User can customize functions that can be executed during training.
- \- scheduler_step_freq: determine when scheduler.step is called. 
　　"batch": step will be called after every optimizer step.
　　"epoch": step will be called after one pass of the DataLoader.
　　"manual":  the scheduler will not be incremented automatically.
　　Now the code is the 'batch' mode, and this can meet basic needs. So this can be optimized as a trick for model training.
- \- feature_shapes & label_shape: required in MLDataset.to_torch(). They're used to check data. In RayDataset.to_torch(), data is checked by comparing      feature_columns and feature_column_dtypes.
- \- shuffle:  https://docs.ray.io/en/master/train/user_guide.html#example-per-epoch-shuffle-pipeline (provided by kira-lin)
- \- fs_directory & compression: Required in RayMLDataset.from_spark().
- \- num_steps & profile=False & reduce_results & info: Required in TorchTrainer.train().

**Can be optimized:**
- User are able to provide their train_fun().
- Multi-task training can be satisfied.
- `scheduler_step_freq` can also be supported.