### PR TITLE
[Enhancement] Stop Spark during training

### DIFF
--- a/python/raydp/torch/estimator.py
+++ b/python/raydp/torch/estimator.py
@@ -30,7 +30,7 @@ from ray.train import Trainer, TrainingCallback, get_dataset_shard
 from ray.data.dataset import Dataset
 from ray.data.impl.arrow_block import ArrowRow
 from raydp import stop_spark
-from raydp.spark import spark_dataframe_to_ray_datase
+from raydp.spark import spark_dataframe_to_ray_dataset
 
 class TorchEstimator(EstimatorInterface, SparkEstimatorInterface):
     """

--- a/python/raydp/torch/estimator.py
+++ b/python/raydp/torch/estimator.py
@@ -305,17 +305,17 @@ class TorchEstimator(EstimatorInterface, SparkEstimatorInterface):
                      stop_spark_after_conversion=False):
         super().fit_on_spark(train_df, evaluate_df)
         train_df = self._check_and_convert(train_df)
-        train_ds = spark_dataframe_to_ray_dataset(train_df, parallelism=self._num_workers,_use_owner=stop_spark_after_conversion)
-
-        evaluate_ds = None    
-
+        train_ds = spark_dataframe_to_ray_dataset(train_df,
+                                                  parallelism=self._num_workers,
+                                                  _use_owner=stop_spark_after_conversion)
+        evaluate_ds = None
         if evaluate_df is not None:
             evaluate_df = self._check_and_convert(evaluate_df)
-            evaluate_ds = spark_dataframe_to_ray_dataset(evaluate_df, parallelism=self._num_workers,_use_owner=stop_spark_after_conversion)    
-        
+            evaluate_ds = spark_dataframe_to_ray_dataset(evaluate_df,
+                                                         parallelism=self._num_workers,
+                                                         _use_owner=stop_spark_after_conversion)
         if stop_spark_after_conversion:
             stop_spark(del_obj_holder=False)
-                
         return self.fit(
             train_ds, evaluate_ds, max_retries)
 

--- a/python/raydp/torch/estimator.py
+++ b/python/raydp/torch/estimator.py
@@ -30,7 +30,7 @@ from ray.train import Trainer, TrainingCallback, get_dataset_shard
 from ray.data.dataset import Dataset
 from ray.data.impl.arrow_block import ArrowRow
 from raydp import stop_spark
-from raydp.spark import spark_dataframe_to_ray_dataset
+from raydp.spark.dataset import spark_dataframe_to_ray_dataset
 
 class TorchEstimator(EstimatorInterface, SparkEstimatorInterface):
     """

--- a/python/raydp/torch/estimator.py
+++ b/python/raydp/torch/estimator.py
@@ -24,13 +24,13 @@ from torch.nn.modules.loss import _Loss as TLoss
 
 from raydp.estimator import EstimatorInterface
 from raydp.spark.interfaces import SparkEstimatorInterface, DF, OPTIONAL_DF
+from raydp import stop_spark
+from raydp.spark import spark_dataframe_to_ray_dataset
 
 from ray import train
 from ray.train import Trainer, TrainingCallback, get_dataset_shard
 from ray.data.dataset import Dataset
 from ray.data.impl.arrow_block import ArrowRow
-from raydp import stop_spark
-from raydp.spark.dataset import spark_dataframe_to_ray_dataset
 
 class TorchEstimator(EstimatorInterface, SparkEstimatorInterface):
     """


### PR DESCRIPTION
# Stop Spark during the training phase

If you set stop_spark_after_conversion to True, you can exploit Spark executor memory to launch other jobs in a Ray cluster.
For example, if your training requires too much time to finish and you want to launch jobs in the meanwhile.

```python
def fit_on_spark(self,
                     train_df: DF,
                     evaluate_df: OPTIONAL_DF = None,
                     max_retries=3,
                     stop_spark_after_conversion=False):
        super().fit_on_spark(train_df, evaluate_df)
        train_df = self._check_and_convert(train_df)
        train_ds = spark_dataframe_to_ray_dataset(train_df,
                                                  parallelism=self._num_workers,
                                                  _use_owner=stop_spark_after_conversion)
        evaluate_ds = None
        if evaluate_df is not None:
            evaluate_df = self._check_and_convert(evaluate_df)
            evaluate_ds = spark_dataframe_to_ray_dataset(evaluate_df,
                                                         parallelism=self._num_workers,
                                                         _use_owner=stop_spark_after_conversion)
        if stop_spark_after_conversion:
            stop_spark(del_obj_holder=False)
        return self.fit(
            train_ds, evaluate_ds, max_retries)
```            