### PR TITLE
Support fractional resource scheduling

### DIFF
--- a/.github/workflows/raydp.yml
+++ b/.github/workflows/raydp.yml
@@ -100,7 +100,13 @@ jobs:
       - name: Test with pytest
         run: |
           ray start --head --num-cpus 4
-          pytest python/raydp/tests/
+          pytest python/raydp/tests/ --deselect python/raydp/tests/test_spark_cluster.py::test_spark_on_fractional_cpu --deselect python/raydp/tests/test_spark_cluster.py::test_spark_on_gpu_machine
+          ray stop --force
+          ray start --head --num-cpus 2
+          pytest -v python/raydp/tests/test_spark_cluster.py::test_spark_on_fractional_cpu
+          ray stop --force
+          ray start --head --num-cpus 2 --num-gpus 2
+          pytest -v python/raydp/tests/test_spark_cluster.py::test_spark_on_gpu_machine
           ray stop --force
       - name: Test Examples
         run: |

--- a/.github/workflows/raydp.yml
+++ b/.github/workflows/raydp.yml
@@ -100,7 +100,8 @@ jobs:
       - name: Test with pytest
         run: |
           ray start --head --num-cpus 4
-          pytest python/raydp/tests/
+          pytest python/raydp/tests/ -m"not error_on_custom_resource"
+          pytest python/raydp/tests/ -m"error_on_custom_resource"
           ray stop --force
       - name: Test Examples
         run: |

--- a/.github/workflows/raydp.yml
+++ b/.github/workflows/raydp.yml
@@ -100,13 +100,13 @@ jobs:
       - name: Test with pytest
         run: |
           ray start --head --num-cpus 4
-          pytest python/raydp/tests/ --deselect python/raydp/tests/test_spark_cluster.py::test_spark_on_fractional_cpu --deselect python/raydp/tests/test_spark_cluster.py::test_spark_on_gpu_machine
+          pytest python/raydp/tests/ -m"not spark_fractional_cpu and not spark_gpu"
           ray stop --force
           ray start --head --num-cpus 2
-          pytest -v python/raydp/tests/test_spark_cluster.py::test_spark_on_fractional_cpu
+          pytest python/raydp/tests/ -m"spark_fractional_cpu"
           ray stop --force
           ray start --head --num-cpus 2 --num-gpus 2
-          pytest -v python/raydp/tests/test_spark_cluster.py::test_spark_on_gpu_machine
+          pytest python/raydp/tests/ -m"spark_gpu"
           ray stop --force
       - name: Test Examples
         run: |

--- a/.github/workflows/raydp.yml
+++ b/.github/workflows/raydp.yml
@@ -100,13 +100,7 @@ jobs:
       - name: Test with pytest
         run: |
           ray start --head --num-cpus 4
-          pytest python/raydp/tests/ -m"not spark_fractional_cpu and not spark_gpu"
-          ray stop --force
-          ray start --head --num-cpus 2
-          pytest python/raydp/tests/ -m"spark_fractional_cpu"
-          ray stop --force
-          ray start --head --num-cpus 2 --num-gpus 2
-          pytest python/raydp/tests/ -m"spark_gpu"
+          pytest python/raydp/tests/
           ray stop --force
       - name: Test Examples
         run: |

--- a/core/src/main/java/org/apache/spark/raydp/RayExecutorUtils.java
+++ b/core/src/main/java/org/apache/spark/raydp/RayExecutorUtils.java
@@ -40,7 +40,6 @@ public class RayExecutorUtils {
       String executorId,
       String appMasterURL,
       double cores,
-      double gpus,
       int memoryInMB,
       Map<String, Double> resources,
       PlacementGroup placementGroup,
@@ -51,9 +50,7 @@ public class RayExecutorUtils {
     creator.setJvmOptions(javaOpts);
     creator.setResource("CPU", cores);
     creator.setResource("memory", toMemoryUnits(memoryInMB));
-    if(gpus > 0d) {
-      creator.setResource("GPU", gpus);
-    }
+
     for (Map.Entry<String, Double> entry: resources.entrySet()) {
       creator.setResource(entry.getKey(), entry.getValue());
     }

--- a/core/src/main/java/org/apache/spark/raydp/RayExecutorUtils.java
+++ b/core/src/main/java/org/apache/spark/raydp/RayExecutorUtils.java
@@ -22,6 +22,7 @@ import io.ray.api.Ray;
 import io.ray.api.call.ActorCreator;
 import java.util.Map;
 import java.util.List;
+import java.util.Optional;
 
 import io.ray.api.placementgroup.PlacementGroup;
 import org.apache.spark.executor.RayCoarseGrainedExecutorBackend;
@@ -39,7 +40,8 @@ public class RayExecutorUtils {
   public static ActorHandle<RayCoarseGrainedExecutorBackend> createExecutorActor(
       String executorId,
       String appMasterURL,
-      int cores,
+      double cores,
+      double gpus,
       int memoryInMB,
       Map<String, Double> resources,
       PlacementGroup placementGroup,
@@ -48,8 +50,11 @@ public class RayExecutorUtils {
     ActorCreator<RayCoarseGrainedExecutorBackend> creator = Ray.actor(
             RayCoarseGrainedExecutorBackend::new, executorId, appMasterURL);
     creator.setJvmOptions(javaOpts);
-    creator.setResource("CPU", (double)cores);
+    creator.setResource("CPU", cores);
     creator.setResource("memory", toMemoryUnits(memoryInMB));
+    if(gpus > 0d) {
+      creator.setResource("GPU", gpus);
+    }
     for (Map.Entry<String, Double> entry: resources.entrySet()) {
       creator.setResource(entry.getKey(), entry.getValue());
     }

--- a/core/src/main/java/org/apache/spark/raydp/RayExecutorUtils.java
+++ b/core/src/main/java/org/apache/spark/raydp/RayExecutorUtils.java
@@ -22,7 +22,6 @@ import io.ray.api.Ray;
 import io.ray.api.call.ActorCreator;
 import java.util.Map;
 import java.util.List;
-import java.util.Optional;
 
 import io.ray.api.placementgroup.PlacementGroup;
 import org.apache.spark.executor.RayCoarseGrainedExecutorBackend;

--- a/core/src/main/java/org/apache/spark/raydp/SparkOnRayConfigs.java
+++ b/core/src/main/java/org/apache/spark/raydp/SparkOnRayConfigs.java
@@ -10,11 +10,5 @@ public class SparkOnRayConfigs {
      */
     public static final String RAY_ACTOR_CPU_RESOURCE = RAY_ACTOR_RESOURCE_PREFIX + ".cpu";
 
-    /**
-     * GPU cores per Ray Actor which host the Spark executor, the resource is used
-     * for scheduling. Default value is 0.
-     */
-    public static final String RAY_ACTOR_GPU_RESOURCE = RAY_ACTOR_RESOURCE_PREFIX + ".gpu";
-
     public static final int DEFAULT_SPARK_CORES_PER_EXECUTOR = 1;
 }

--- a/core/src/main/java/org/apache/spark/raydp/SparkOnRayConfigs.java
+++ b/core/src/main/java/org/apache/spark/raydp/SparkOnRayConfigs.java
@@ -1,17 +1,20 @@
 package org.apache.spark.raydp;
 
 public class SparkOnRayConfigs {
-    public static final String SPARK_CONFIG_ACTOR_RESOURCE_PREFIX = "spark.ray.actor.resource";
+    public static final String RAY_ACTOR_RESOURCE_PREFIX = "spark.ray.actor.resource";
     /**
-     * CPU cores per Ray Actor which host the Spark executor, the resource is used for scheduling. Default value is 1.
-     * This is different from spark.executor.cores, which defines the task parallelism inside a stage.
+     * CPU cores per Ray Actor which host the Spark executor, the resource is used
+     * for scheduling. Default value is 1.
+     * This is different from spark.executor.cores, which defines the task parallelism
+     * inside a stage.
      */
-    public static final String SPARK_CONFIG_ACTOR_CPU_RESOURCE = SPARK_CONFIG_ACTOR_RESOURCE_PREFIX + ".cpu";
+    public static final String RAY_ACTOR_CPU_RESOURCE = RAY_ACTOR_RESOURCE_PREFIX + ".cpu";
 
     /**
-     * GPU cores per Ray Actor which host the Spark executor, the resource is used for scheduling. Default value is 0.
+     * GPU cores per Ray Actor which host the Spark executor, the resource is used
+     * for scheduling. Default value is 0.
      */
-    public static final String SPARK_CONFIG_ACTOR_GPU_RESOURCE = SPARK_CONFIG_ACTOR_RESOURCE_PREFIX + ".gpu";
+    public static final String RAY_ACTOR_GPU_RESOURCE = RAY_ACTOR_RESOURCE_PREFIX + ".gpu";
 
     public static final int DEFAULT_SPARK_CORES_PER_EXECUTOR = 1;
 }

--- a/core/src/main/java/org/apache/spark/raydp/SparkOnRayConfigs.java
+++ b/core/src/main/java/org/apache/spark/raydp/SparkOnRayConfigs.java
@@ -1,0 +1,17 @@
+package org.apache.spark.raydp;
+
+public class SparkOnRayConfigs {
+    public static final String SPARK_CONFIG_ACTOR_RESOURCE_PREFIX = "spark.ray.actor.resource";
+    /**
+     * CPU cores per Ray Actor which host the Spark executor, the resource is used for scheduling. Default value is 1.
+     * This is different from spark.executor.cores, which defines the task parallelism inside a stage.
+     */
+    public static final String SPARK_CONFIG_ACTOR_CPU_RESOURCE = SPARK_CONFIG_ACTOR_RESOURCE_PREFIX + ".cpu";
+
+    /**
+     * GPU cores per Ray Actor which host the Spark executor, the resource is used for scheduling. Default value is 0.
+     */
+    public static final String SPARK_CONFIG_ACTOR_GPU_RESOURCE = SPARK_CONFIG_ACTOR_RESOURCE_PREFIX + ".gpu";
+
+    public static final int DEFAULT_SPARK_CORES_PER_EXECUTOR = 1;
+}

--- a/core/src/main/scala/org/apache/spark/deploy/raydp/ApplicationDescription.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/raydp/ApplicationDescription.scala
@@ -39,14 +39,13 @@ private[spark] case class ApplicationDescription(
     rayActorCPU: Double,
     command: Command,
     user: String = System.getProperty("user.name", "<unknown>"),
-    resourceReqsPerExecutor: Map[String, Double] = Map.empty,
-    rayActorGPU: Double = 0d) {
+    resourceReqsPerExecutor: Map[String, Double] = Map.empty) {
 
   def withNewCommand(newCommand: Command): ApplicationDescription = {
     ApplicationDescription(name = name,
       numExecutors = numExecutors, coresPerExecutor = coresPerExecutor,
       memoryPerExecutorMB = memoryPerExecutorMB, command = newCommand, user = user,
       resourceReqsPerExecutor = resourceReqsPerExecutor,
-      rayActorCPU = rayActorCPU, rayActorGPU = rayActorGPU)
+      rayActorCPU = rayActorCPU)
   }
 }

--- a/core/src/main/scala/org/apache/spark/deploy/raydp/ApplicationDescription.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/raydp/ApplicationDescription.scala
@@ -43,8 +43,10 @@ private[spark] case class ApplicationDescription(
     rayActorGPU: Double = 0d) {
 
   def withNewCommand(newCommand: Command): ApplicationDescription = {
-    ApplicationDescription(name = name, numExecutors = numExecutors, coresPerExecutor = coresPerExecutor,
+    ApplicationDescription(name = name,
+      numExecutors = numExecutors, coresPerExecutor = coresPerExecutor,
       memoryPerExecutorMB = memoryPerExecutorMB, command = newCommand, user = user,
-      resourceReqsPerExecutor = resourceReqsPerExecutor, rayActorCPU = rayActorCPU, rayActorGPU = rayActorGPU)
+      resourceReqsPerExecutor = resourceReqsPerExecutor,
+      rayActorCPU = rayActorCPU, rayActorGPU = rayActorGPU)
   }
 }

--- a/core/src/main/scala/org/apache/spark/deploy/raydp/ApplicationDescription.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/raydp/ApplicationDescription.scala
@@ -36,12 +36,15 @@ private[spark] case class ApplicationDescription(
     numExecutors: Int,
     coresPerExecutor: Option[Int],
     memoryPerExecutorMB: Int,
+    rayActorCPU: Double,
     command: Command,
     user: String = System.getProperty("user.name", "<unknown>"),
-    resourceReqsPerExecutor: Map[String, Double] = Map.empty) {
+    resourceReqsPerExecutor: Map[String, Double] = Map.empty,
+    rayActorGPU: Double = 0d) {
 
   def withNewCommand(newCommand: Command): ApplicationDescription = {
-    ApplicationDescription(name, numExecutors, coresPerExecutor, memoryPerExecutorMB,
-      newCommand, user, resourceReqsPerExecutor)
+    ApplicationDescription(name = name, numExecutors = numExecutors, coresPerExecutor = coresPerExecutor,
+      memoryPerExecutorMB = memoryPerExecutorMB, command = newCommand, user = user,
+      resourceReqsPerExecutor = resourceReqsPerExecutor, rayActorCPU = rayActorCPU, rayActorGPU = rayActorGPU)
   }
 }

--- a/core/src/main/scala/org/apache/spark/deploy/raydp/RayAppMaster.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/raydp/RayAppMaster.scala
@@ -21,18 +21,15 @@ import java.io.File
 import java.text.SimpleDateFormat
 import java.util.{Date, Locale, Optional}
 import javax.xml.bind.DatatypeConverter
-
 import scala.collection.JavaConverters._
 import scala.collection.mutable.HashMap
-
 import io.ray.api.{ActorHandle, PlacementGroups, Ray}
 import io.ray.api.id.PlacementGroupId
 import io.ray.api.placementgroup.PlacementGroup
 import io.ray.runtime.config.RayConfig
-
 import org.apache.spark.{RayDPException, SecurityManager, SparkConf}
 import org.apache.spark.internal.Logging
-import org.apache.spark.raydp.RayExecutorUtils
+import org.apache.spark.raydp.{RayExecutorUtils, SparkOnRayConfigs}
 import org.apache.spark.rpc._
 import org.apache.spark.util.ShutdownHookManager
 import org.apache.spark.util.Utils
@@ -229,17 +226,29 @@ class RayAppMaster(host: String,
     }
 
     private def requestNewExecutor(): Unit = {
-      val cores = appInfo.desc.coresPerExecutor.getOrElse(1)
+      val sparkCoresPerExecutor = appInfo.desc
+        .coresPerExecutor
+        .getOrElse(SparkOnRayConfigs.DEFAULT_SPARK_CORES_PER_EXECUTOR)
+      val rayActorCPU = this.appInfo.desc.rayActorCPU
+      val rayActorGPU = this.appInfo.desc.rayActorGPU
+
       val memory = appInfo.desc.memoryPerExecutorMB
       val executorId = s"${appInfo.getNextExecutorId()}"
+
+      logInfo(s"Requesting Spark executor with Ray logical resource {CPU: ${rayActorCPU}, GPU: ${rayActorGPU}}..")
+      // TODO: Support generic fractional logical resources using prefix spark.ray.actor.resource.*
+
       val handler = RayExecutorUtils.createExecutorActor(
-        executorId, getAppMasterEndpointUrl(), cores,
+        executorId, getAppMasterEndpointUrl(),
+        rayActorCPU, rayActorGPU,
         memory,
+        // This won't work, Spark expect integer in custom resources,
+        // please see python test test_spark_on_fractional_custom_resource
         appInfo.desc.resourceReqsPerExecutor.map(pair => (pair._1, Double.box(pair._2))).asJava,
         placementGroup,
         getNextBundleIndex,
         seqAsJavaList(appInfo.desc.command.javaOpts))
-      appInfo.addPendingRegisterExecutor(executorId, handler, cores, memory)
+      appInfo.addPendingRegisterExecutor(executorId, handler, sparkCoresPerExecutor, memory)
     }
 
     private def appendActorClasspath(javaOpts: Seq[String]): Seq[String] = {

--- a/core/src/main/scala/org/apache/spark/deploy/raydp/RayAppMaster.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/raydp/RayAppMaster.scala
@@ -232,18 +232,17 @@ class RayAppMaster(host: String,
         .coresPerExecutor
         .getOrElse(SparkOnRayConfigs.DEFAULT_SPARK_CORES_PER_EXECUTOR)
       val rayActorCPU = this.appInfo.desc.rayActorCPU
-      val rayActorGPU = this.appInfo.desc.rayActorGPU
 
       val memory = appInfo.desc.memoryPerExecutorMB
       val executorId = s"${appInfo.getNextExecutorId()}"
 
       logInfo(s"Requesting Spark executor with Ray logical resource " +
-        s"{ CPU: ${rayActorCPU}, GPU: ${rayActorGPU} }..")
+        s"{ CPU: ${rayActorCPU} }..")
       // TODO: Support generic fractional logical resources using prefix spark.ray.actor.resource.*
 
       val handler = RayExecutorUtils.createExecutorActor(
         executorId, getAppMasterEndpointUrl(),
-        rayActorCPU, rayActorGPU,
+        rayActorCPU,
         memory,
         // This won't work, Spark expect integer in custom resources,
         // please see python test test_spark_on_fractional_custom_resource

--- a/core/src/main/scala/org/apache/spark/deploy/raydp/RayAppMaster.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/raydp/RayAppMaster.scala
@@ -19,19 +19,21 @@ package org.apache.spark.deploy.raydp
 
 import java.io.File
 import java.text.SimpleDateFormat
-import java.util.{Date, Locale, Optional}
+import java.util.{Date, Locale}
 import javax.xml.bind.DatatypeConverter
+
 import scala.collection.JavaConverters._
 import scala.collection.mutable.HashMap
-import io.ray.api.{ActorHandle, PlacementGroups, Ray}
+
+import io.ray.api.{ActorHandle, PlacementGroups}
 import io.ray.api.id.PlacementGroupId
 import io.ray.api.placementgroup.PlacementGroup
 import io.ray.runtime.config.RayConfig
+
 import org.apache.spark.{RayDPException, SecurityManager, SparkConf}
 import org.apache.spark.internal.Logging
 import org.apache.spark.raydp.{RayExecutorUtils, SparkOnRayConfigs}
 import org.apache.spark.rpc._
-import org.apache.spark.util.ShutdownHookManager
 import org.apache.spark.util.Utils
 
 class RayAppMaster(host: String,
@@ -235,7 +237,8 @@ class RayAppMaster(host: String,
       val memory = appInfo.desc.memoryPerExecutorMB
       val executorId = s"${appInfo.getNextExecutorId()}"
 
-      logInfo(s"Requesting Spark executor with Ray logical resource {CPU: ${rayActorCPU}, GPU: ${rayActorGPU}}..")
+      logInfo(s"Requesting Spark executor with Ray logical resource " +
+        s"{ CPU: ${rayActorCPU}, GPU: ${rayActorGPU} }..")
       // TODO: Support generic fractional logical resources using prefix spark.ray.actor.resource.*
 
       val handler = RayExecutorUtils.createExecutorActor(

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/raydp/RayCoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/raydp/RayCoarseGrainedSchedulerBackend.scala
@@ -150,14 +150,12 @@ class RayCoarseGrainedSchedulerBackend(
       .getOrElse(SparkOnRayConfigs.DEFAULT_SPARK_CORES_PER_EXECUTOR)
     val rayActorCPU = conf.get(SparkOnRayConfigs.RAY_ACTOR_CPU_RESOURCE,
       sparkCoresPerExecutor.toString).toDouble
-    val rayActorGPU = conf.get(SparkOnRayConfigs.RAY_ACTOR_GPU_RESOURCE,
-      0.toString).toDouble
 
     val appDesc = ApplicationDescription(name = sc.appName, numExecutors = numExecutors,
       coresPerExecutor = coresPerExecutor, memoryPerExecutorMB = sc.executorMemory,
       command = command,
       resourceReqsPerExecutor = resourcesInMap,
-      rayActorCPU = rayActorCPU, rayActorGPU = rayActorGPU)
+      rayActorCPU = rayActorCPU)
 
     val rpcEnv = sc.env.rpcEnv
     appMasterRef.set(rpcEnv.setupEndpoint(

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/raydp/RayCoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/raydp/RayCoarseGrainedSchedulerBackend.scala
@@ -20,14 +20,17 @@ package org.apache.spark.scheduler.cluster.raydp
 import java.net.URI
 import java.util.concurrent.Semaphore
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
+
 import scala.collection.JavaConverters._
 import scala.collection.mutable.HashMap
 import scala.concurrent.Future
+
 import io.ray.api.{ActorHandle, Ray}
+
 import org.apache.spark.{RayDPException, SparkConf, SparkContext}
 import org.apache.spark.deploy.raydp._
 import org.apache.spark.deploy.security.HadoopDelegationTokenManager
-import org.apache.spark.internal.{Logging, config}
+import org.apache.spark.internal.{config, Logging}
 import org.apache.spark.launcher.{LauncherBackend, SparkAppHandle}
 import org.apache.spark.raydp.SparkOnRayConfigs
 import org.apache.spark.resource.{ResourceProfile, ResourceRequirement, ResourceUtils}
@@ -143,13 +146,18 @@ class RayCoarseGrainedSchedulerBackend(
       conf, config.SPARK_EXECUTOR_PREFIX)
     val resourcesInMap = transferResourceRequirements(executorResourceReqs)
     val numExecutors = conf.get(config.EXECUTOR_INSTANCES).get
-    val sparkCoresPerExecutor = coresPerExecutor.getOrElse(SparkOnRayConfigs.DEFAULT_SPARK_CORES_PER_EXECUTOR)
-    val rayActorCPU = conf.get(SparkOnRayConfigs.SPARK_CONFIG_ACTOR_CPU_RESOURCE, sparkCoresPerExecutor.toString).toDouble
-    val rayActorGPU = conf.get(SparkOnRayConfigs.SPARK_CONFIG_ACTOR_GPU_RESOURCE, 0.toString).toDouble
+    val sparkCoresPerExecutor = coresPerExecutor
+      .getOrElse(SparkOnRayConfigs.DEFAULT_SPARK_CORES_PER_EXECUTOR)
+    val rayActorCPU = conf.get(SparkOnRayConfigs.RAY_ACTOR_CPU_RESOURCE,
+      sparkCoresPerExecutor.toString).toDouble
+    val rayActorGPU = conf.get(SparkOnRayConfigs.RAY_ACTOR_GPU_RESOURCE,
+      0.toString).toDouble
 
     val appDesc = ApplicationDescription(name = sc.appName, numExecutors = numExecutors,
-      coresPerExecutor = coresPerExecutor, memoryPerExecutorMB = sc.executorMemory, command = command,
-      resourceReqsPerExecutor = resourcesInMap, rayActorCPU = rayActorCPU, rayActorGPU = rayActorGPU)
+      coresPerExecutor = coresPerExecutor, memoryPerExecutorMB = sc.executorMemory,
+      command = command,
+      resourceReqsPerExecutor = resourcesInMap,
+      rayActorCPU = rayActorCPU, rayActorGPU = rayActorGPU)
 
     val rpcEnv = sc.env.rpcEnv
     appMasterRef.set(rpcEnv.setupEndpoint(

--- a/python/raydp/context.py
+++ b/python/raydp/context.py
@@ -139,6 +139,8 @@ class _SparkContext(ContextDecorator):
                 ray.util.remove_placement_group(self._placement_group)
                 self._placement_group = None
             self._placement_group_strategy = None
+        if self._configs is not None:
+            self._configs = None
 
     def __enter__(self):
         self.get_or_create_session()
@@ -199,6 +201,8 @@ def init_spark(app_name: str,
                     configs)
                 return _global_spark_context.get_or_create_session()
             except:
+                if _global_spark_context is not None:
+                    _global_spark_context.stop()
                 _global_spark_context = None
                 raise
         else:

--- a/python/raydp/tests/conftest.py
+++ b/python/raydp/tests/conftest.py
@@ -63,6 +63,18 @@ def spark_on_ray_small(request):
 
 
 @pytest.fixture(scope="function", params=["localhost:6379", "ray://localhost:10001"])
+def spark_on_ray_fraction_custom_resource(request):
+    ray.shutdown()
+    ray.init(address=request.param)
+
+    def stop_all():
+        raydp.stop_spark()
+        ray.shutdown()
+
+    request.addfinalizer(stop_all)
+
+
+@pytest.fixture(scope="function", params=["localhost:6379", "ray://localhost:10001"])
 def spark_on_ray_gpu(request):
     if not ray.is_initialized():
         ray.init(num_gpus=2, num_cpus=2)

--- a/python/raydp/tests/conftest.py
+++ b/python/raydp/tests/conftest.py
@@ -62,10 +62,12 @@ def spark_on_ray_small(request):
     return spark
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture(scope="function", params=["localhost:6379", "ray://localhost:10001"])
 def spark_on_ray_gpu(request):
-    ray.shutdown()
-    ray.init(num_gpus=2, num_cpus=2)
+    if not ray.is_initialized():
+        ray.init(num_gpus=2, num_cpus=2)
+    else:
+        ray.init(address=request.param)
 
     spark = raydp.init_spark(app_name="test_gpu",
                              num_executors=1, executor_cores=1, executor_memory="500 M",
@@ -79,10 +81,12 @@ def spark_on_ray_gpu(request):
     return spark
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture(scope="function", params=["localhost:6379", "ray://localhost:10001"])
 def spark_on_ray_fractional_cpu(request):
-    ray.shutdown()
-    ray.init(num_cpus=2)
+    if not ray.is_initialized():
+        ray.init(num_cpus=2)
+    else:
+        ray.init(address=request.param)
 
     spark = raydp.init_spark(app_name="test_cpu_fraction",
                              num_executors=1, executor_cores=3, executor_memory="500 M",

--- a/python/raydp/tests/conftest.py
+++ b/python/raydp/tests/conftest.py
@@ -81,32 +81,6 @@ def spark_on_ray_fraction_custom_resource(request):
 
 
 @pytest.fixture(scope="function")
-def spark_on_ray_gpu(request):
-    ray.shutdown()
-    # https://docs.ray.io/en/latest/ray-core/examples/testing-tips.html#tip-4-create-a-mini-cluster-with-ray-cluster-utils-cluster
-    cluster = Cluster(
-        initialize_head=True,
-        head_node_args={
-            "num_cpus": 2,
-            "num_gpus": 2
-        })
-
-    ray.init(address=cluster.address)
-
-    spark = raydp.init_spark(app_name="test_gpu",
-                             num_executors=1, executor_cores=1, executor_memory="500 M",
-                             configs={"spark.ray.actor.resource.gpu": "1",
-                                      "spark.ray.actor.resource.cpu": "1"})
-
-    def stop_all():
-        raydp.stop_spark()
-        ray.shutdown()
-
-    request.addfinalizer(stop_all)
-    return spark
-
-
-@pytest.fixture(scope="function")
 def spark_on_ray_fractional_cpu(request):
     ray.shutdown()
     cluster = Cluster(
@@ -119,9 +93,7 @@ def spark_on_ray_fractional_cpu(request):
 
     spark = raydp.init_spark(app_name="test_cpu_fraction",
                              num_executors=1, executor_cores=3, executor_memory="500 M",
-                             configs={"spark.ray.actor.resource.cpu": "0.1",
-                                      "spark.ray.actor.resource.gpu": "0",   # TODO: Fix this, Spark config have stale value
-                                      })
+                             configs={"spark.ray.actor.resource.cpu": "0.1"})
 
     def stop_all():
         raydp.stop_spark()

--- a/python/raydp/tests/conftest.py
+++ b/python/raydp/tests/conftest.py
@@ -65,6 +65,7 @@ def spark_on_ray_small(request):
 
 @pytest.fixture(scope="function")
 def spark_on_ray_fraction_custom_resource(request):
+    ray.shutdown()
     cluster = Cluster(
         initialize_head=True,
         head_node_args={
@@ -81,6 +82,7 @@ def spark_on_ray_fraction_custom_resource(request):
 
 @pytest.fixture(scope="function")
 def spark_on_ray_gpu(request):
+    ray.shutdown()
     # https://docs.ray.io/en/latest/ray-core/examples/testing-tips.html#tip-4-create-a-mini-cluster-with-ray-cluster-utils-cluster
     cluster = Cluster(
         initialize_head=True,
@@ -93,7 +95,8 @@ def spark_on_ray_gpu(request):
 
     spark = raydp.init_spark(app_name="test_gpu",
                              num_executors=1, executor_cores=1, executor_memory="500 M",
-                             configs={"spark.ray.actor.resource.gpu": "1"})
+                             configs={"spark.ray.actor.resource.gpu": "1",
+                                      "spark.ray.actor.resource.cpu": "1"})
 
     def stop_all():
         raydp.stop_spark()
@@ -105,6 +108,7 @@ def spark_on_ray_gpu(request):
 
 @pytest.fixture(scope="function")
 def spark_on_ray_fractional_cpu(request):
+    ray.shutdown()
     cluster = Cluster(
         initialize_head=True,
         head_node_args={
@@ -115,7 +119,9 @@ def spark_on_ray_fractional_cpu(request):
 
     spark = raydp.init_spark(app_name="test_cpu_fraction",
                              num_executors=1, executor_cores=3, executor_memory="500 M",
-                             configs={"spark.ray.actor.resource.cpu": "0.1"})
+                             configs={"spark.ray.actor.resource.cpu": "0.1",
+                                      "spark.ray.actor.resource.gpu": "0",   # TODO: Fix this, Spark config have stale value
+                                      })
 
     def stop_all():
         raydp.stop_spark()

--- a/python/raydp/tests/test_spark_cluster.py
+++ b/python/raydp/tests/test_spark_cluster.py
@@ -51,19 +51,14 @@ def test_spark_on_fractional_cpu(spark_on_ray_fractional_cpu):
     assert result == 10
 
 
-def test_spark_on_fractional_custom_resource():
+def test_spark_on_fractional_custom_resource(spark_on_ray_fraction_custom_resource):
     try:
-        ray.shutdown()
-        ray.init()
-
         spark = raydp.init_spark(app_name="test_cpu_fraction",
                                  num_executors=1, executor_cores=3, executor_memory="500 M",
                                  configs={"spark.executor.resource.CUSTOM.amount": "0.1"})
         spark.range(0, 10).count()
         assert False
     except Exception:
-        ray.shutdown()
-        raydp.stop_spark()
         assert True
 
 

--- a/python/raydp/tests/test_spark_cluster.py
+++ b/python/raydp/tests/test_spark_cluster.py
@@ -38,12 +38,6 @@ def test_spark(spark_on_ray_small):
     assert result == 10
 
 
-def test_spark_on_gpu_machine(spark_on_ray_gpu):
-    spark = spark_on_ray_gpu
-    result = spark.range(0, 10).count()
-    assert result == 10
-
-
 def test_spark_on_fractional_cpu(spark_on_ray_fractional_cpu):
     spark = spark_on_ray_fractional_cpu
     result = spark.range(0, 10).count()

--- a/python/raydp/tests/test_spark_cluster.py
+++ b/python/raydp/tests/test_spark_cluster.py
@@ -29,6 +29,7 @@ from ray.util.placement_group import placement_group_table
 import raydp
 import raydp.utils as utils
 from raydp.spark.ray_cluster_master import RayDPSparkMaster, RAYDP_SPARK_MASTER_NAME
+from ray.cluster_utils import Cluster
 
 
 def test_spark(spark_on_ray_small):
@@ -49,15 +50,18 @@ def test_spark_on_fractional_cpu(spark_on_ray_fractional_cpu):
     assert result == 10
 
 
+@pytest.mark.error_on_custom_resource
 def test_spark_on_fractional_custom_resource(spark_on_ray_fraction_custom_resource):
     try:
-        spark = raydp.init_spark(app_name="test_cpu_fraction",
+        spark = raydp.init_spark(app_name="test_custom_resource_fraction",
                                  num_executors=1, executor_cores=3, executor_memory="500 M",
                                  configs={"spark.executor.resource.CUSTOM.amount": "0.1"})
         spark.range(0, 10).count()
-        assert False
     except Exception:
         assert True
+        return
+
+    assert False
 
 
 def test_spark_remote(ray_cluster):
@@ -165,7 +169,13 @@ def test_placement_group(ray_cluster):
 
 def test_custom_installed_spark(custom_spark_dir):
     os.environ["SPARK_HOME"] = custom_spark_dir
-    ray.shutdown()
+    cluster = Cluster(
+        initialize_head=True,
+        head_node_args={
+            "num_cpus": 2
+        })
+
+    ray.init(address=cluster.address)
     spark = raydp.init_spark("custom_install_test", 1, 1, "500 M")
     spark_master_actor = ray.get_actor(name=RAYDP_SPARK_MASTER_NAME)
     spark_home = ray.get(spark_master_actor.get_spark_home.remote())

--- a/python/raydp/tests/test_spark_cluster.py
+++ b/python/raydp/tests/test_spark_cluster.py
@@ -52,7 +52,7 @@ def test_spark_on_fractional_cpu(spark_on_ray_fractional_cpu):
 def test_spark_on_fractional_custom_resource():
     try:
         ray.shutdown()
-        ray.init(num_cpus=2)
+        ray.init()
 
         spark = raydp.init_spark(app_name="test_cpu_fraction",
                                  num_executors=1, executor_cores=3, executor_memory="500 M",

--- a/python/raydp/tests/test_spark_cluster.py
+++ b/python/raydp/tests/test_spark_cluster.py
@@ -37,12 +37,14 @@ def test_spark(spark_on_ray_small):
     assert result == 10
 
 
+@pytest.mark.spark_gpu
 def test_spark_on_gpu_machine(spark_on_ray_gpu):
     spark = spark_on_ray_gpu
     result = spark.range(0, 10).count()
     assert result == 10
 
 
+@pytest.mark.spark_fractional_cpu
 def test_spark_on_fractional_cpu(spark_on_ray_fractional_cpu):
     spark = spark_on_ray_fractional_cpu
     result = spark.range(0, 10).count()

--- a/python/raydp/tests/test_spark_cluster.py
+++ b/python/raydp/tests/test_spark_cluster.py
@@ -37,14 +37,12 @@ def test_spark(spark_on_ray_small):
     assert result == 10
 
 
-@pytest.mark.spark_gpu
 def test_spark_on_gpu_machine(spark_on_ray_gpu):
     spark = spark_on_ray_gpu
     result = spark.range(0, 10).count()
     assert result == 10
 
 
-@pytest.mark.spark_fractional_cpu
 def test_spark_on_fractional_cpu(spark_on_ray_fractional_cpu):
     spark = spark_on_ray_fractional_cpu
     result = spark.range(0, 10).count()

--- a/python/raydp/tests/test_spark_cluster.py
+++ b/python/raydp/tests/test_spark_cluster.py
@@ -37,6 +37,34 @@ def test_spark(spark_on_ray_small):
     assert result == 10
 
 
+def test_spark_on_gpu_machine(spark_on_ray_gpu):
+    spark = spark_on_ray_gpu
+    result = spark.range(0, 10).count()
+    assert result == 10
+
+
+def test_spark_on_fractional_cpu(spark_on_ray_fractional_cpu):
+    spark = spark_on_ray_fractional_cpu
+    result = spark.range(0, 10).count()
+    assert result == 10
+
+
+def test_spark_on_fractional_custom_resource():
+    try:
+        ray.shutdown()
+        ray.init(num_cpus=2)
+
+        spark = raydp.init_spark(app_name="test_cpu_fraction",
+                                 num_executors=1, executor_cores=3, executor_memory="500 M",
+                                 configs={"spark.executor.resource.CUSTOM.amount": "0.1"})
+        spark.range(0, 10).count()
+        assert False
+    except Exception:
+        ray.shutdown()
+        raydp.stop_spark()
+        assert True
+
+
 def test_spark_remote(ray_cluster):
     @ray.remote
     class SparkRemote:


### PR DESCRIPTION
Support fractional CPU and GPU resource scheduling. This PR actually achieve three goals:
* Support schedule multiple executors in one vCPU, with each executor has 1 spark core (for parallism, like how Spark CPU request work on Kubernetes, but no limit), using `spark.ray.actor.resource.cpu` config.
* Support scheduling on GPU nodes, using `spark.ray.actor.resource.gpu` config.
* Support schedule multiple executors in one GPU.

For more details, please refer to [this RFC](https://github.com/oap-project/raydp/issues/259).
