### PR TITLE
Fix the pyspark driver log level

### DIFF
--- a/doc/spark_on_ray.md
+++ b/doc/spark_on_ray.md
@@ -60,3 +60,6 @@ spark = raydp.init_spark(...,enable_hive=True)
 spark.sql("select * from db.xxx").show()
 ```
 
+### Logging
++ Driver Log: By default, the spark driver log level is WARN. After getting a Spark session by running `spark = raydp.init_spark`, you can change the log level for example `spark.sparkContext.setLogLevel("INFO")`. You will also see some AppMaster INFO logs on the driver. This is because Ray redirects the actor logs to driver by default. To disable logging to driver, you can set it in Ray init `ray.init(log_to_driver=False)`
++ Executor Log: The spark executor logs are stored in Ray's logging directory. By default they are available at /tmp/ray/session_\*/logs/java-worker-\*.log

--- a/python/raydp/spark/ray_cluster.py
+++ b/python/raydp/spark/ray_cluster.py
@@ -21,6 +21,7 @@ from typing import Any, Dict, Optional
 
 import ray
 import ray._private.services
+import pyspark
 from pyspark.sql.session import SparkSession
 
 from raydp.services import Cluster
@@ -67,13 +68,17 @@ class SparkCluster(Cluster):
         extra_conf["spark.driver.bindAddress"] = str(driver_node_ip)
         RAYDP_CP = os.path.abspath(os.path.join(os.path.abspath(__file__), "../../jars/*"))
         RAY_CP = os.path.abspath(os.path.join(os.path.dirname(ray.__file__), "jars/*"))
+        # A workaround for the spark driver to bind to its slf4j-log4j jar instead of the one from
+        # Ray's jar. Without this, the driver produces INFO logs and the level cannot be changed.
+        spark_home = os.environ.get("SPARK_HOME", os.path.dirname(pyspark.__file__))
+        log4j_path = os.path.abspath(os.path.join(spark_home, "jars/slf4j-log4j*.jar"))
         try:
             extra_jars = [extra_conf["spark.jars"]]
         except KeyError:
             extra_jars = []
         extra_conf["spark.jars"] = ",".join(glob.glob(RAYDP_CP) + extra_jars)
         driver_cp_key = "spark.driver.extraClassPath"
-        driver_cp = ":".join(glob.glob(RAYDP_CP) + glob.glob(RAY_CP))
+        driver_cp = ":".join(glob.glob(log4j_path) + glob.glob(RAYDP_CP) + glob.glob(RAY_CP))
         if driver_cp_key in extra_conf:
             extra_conf[driver_cp_key] = driver_cp + ":" + extra_conf[driver_cp_key]
         else:


### PR DESCRIPTION
Because Ray's jar is added in "spark.driver.extraClassPath", spark driver's SL4j binds the jar from Ray's jar instead of the one in Spark. This causes many INFO logs on the driver. It also makes `sparkContext.setLogLevel` stop working. As a workaround, we can add the spark slf4j-log4j on the driver extraClassPath first so the driver can still binds to the correct jar.

There are still Spark app master INFO logs printed on the driver as Ray redirects the actor logs to driver. To disable it, we can set the configuration in Ray init i.e. `ray.init(log_to_driver=False)`. 