### PR TITLE
Implement resource based node affinity for Spark Driver

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -50,6 +50,12 @@ popd # core dir
 # build python part
 RAYDP_PACKAGE_NAME=${RAYDP_PACKAGE_NAME:-raydp}
 PYTHON_DIR="${CURRENT_DIR}/python"
+
+if [[ -d "${PYTHON_DIR}/build" ]];
+then
+  rm -rf "${PYTHON_DIR}/build"
+fi
+
 pushd ${PYTHON_DIR}
 python setup.py bdist_wheel
 cp ${PYTHON_DIR}/dist/${RAYDP_PACKAGE_NAME}-* ${DIST_PATH}

--- a/core/raydp-main/src/main/scala/org/apache/spark/deploy/raydp/AppMasterEntryPoint.scala
+++ b/core/raydp-main/src/main/scala/org/apache/spark/deploy/raydp/AppMasterEntryPoint.scala
@@ -20,10 +20,13 @@ package org.apache.spark.deploy.raydp
 import java.io.{DataOutputStream, File, FileOutputStream}
 import java.net.InetAddress
 import java.nio.file.Files
-import py4j.GatewayServer
-import org.apache.spark.internal.Logging
 
 import scala.util.Try
+
+import py4j.GatewayServer
+
+import org.apache.spark.internal.Logging
+
 
 class AppMasterEntryPoint {
   private val appMaster: AppMasterJavaBridge = new AppMasterJavaBridge()

--- a/doc/spark_on_ray.md
+++ b/doc/spark_on_ray.md
@@ -1,3 +1,26 @@
+### How to schedule Spark Master to a designated node
+
+RayDP will create a ray actor called `RayDPSparkMaster`, which will then launch the java process, acting like a Master in a tradtional Spark cluster. By default, this actor could be scheduled to any node in the ray cluster. If you want it to be on a particular node, you can assign some custom resources to that node, and request those resources when starting `RayDPSparkMaster` by setting `spark.ray.raydp_spark_master.resource.*` in `init_spark`.
+
+As an example:
+
+```python
+raydp.init_spark(...,
+configs = {
+    # ... other configs
+    'spark.ray.raydp_spark_master.resource.CPU': 0,
+    'spark.ray.raydp_spark_master.resource.spark_master': 1,  # Force Spark driver related actor run on headnode
+})
+```
+
+In cluster config yaml:
+```yaml
+available_node_types:
+  ray.head.default:
+    resources:
+      CPU: 0    # We intentionally set this to 0 so not executors are on headnode
+      spark_master: 100  # Just gave it a large enough number so all drivers are there
+```
 
 ### External Shuffle Service & Dynamic Resource Allocation
 

--- a/doc/spark_on_ray.md
+++ b/doc/spark_on_ray.md
@@ -1,4 +1,4 @@
-### How to schedule Spark Master to a designated node
+### Spark master node affinity
 
 RayDP will create a ray actor called `RayDPSparkMaster`, which will then launch the java process, acting like a Master in a tradtional Spark cluster. By default, this actor could be scheduled to any node in the ray cluster. If you want it to be on a particular node, you can assign some custom resources to that node, and request those resources when starting `RayDPSparkMaster` by setting `spark.ray.raydp_spark_master.resource.*` in `init_spark`.
 
@@ -18,7 +18,7 @@ In cluster config yaml:
 available_node_types:
   ray.head.default:
     resources:
-      CPU: 0    # We intentionally set this to 0 so not executors are on headnode
+      CPU: 0    # We intentionally set this to 0 so no executor is on headnode
       spark_master: 100  # Just gave it a large enough number so all drivers are there
 ```
 

--- a/python/raydp/context.py
+++ b/python/raydp/context.py
@@ -108,7 +108,7 @@ class _SparkContext(ContextDecorator):
 
     def _get_object_holder_resources(self) -> Dict[str, float]:
         resources = {}
-        object_holder_config_prefix = 'spark.ray.raydp_obj_holder.resource.'
+        object_holder_config_prefix = "spark.ray.raydp_obj_holder.resource."
         for key in self._configs:
             if key.startswith(object_holder_config_prefix):
                 resource_name = key[len(object_holder_config_prefix):]
@@ -123,9 +123,9 @@ class _SparkContext(ContextDecorator):
         object_holder_resource = self._get_object_holder_resources()
 
         if object_holder_resource:
-            if 'CPU' in object_holder_resource:
-                num_cpu = object_holder_resource['CPU']
-                object_holder_resource.pop('CPU', None)
+            if "CPU" in object_holder_resource:
+                num_cpu = object_holder_resource["CPU"]
+                object_holder_resource.pop("CPU", None)
             self.handle = RayDPConversionHelper.options(name=obj_holder_name,
                                                         num_cpus=num_cpu,
                                                         resources=object_holder_resource).remote()

--- a/python/raydp/spark/ray_cluster.py
+++ b/python/raydp/spark/ray_cluster.py
@@ -44,9 +44,9 @@ class SparkCluster(Cluster):
 
         if resources:
             num_cpu = 1
-            if 'CPU' in resources:
-                num_cpu = resources['CPU']
-                resources.pop('CPU', None)
+            if "CPU" in resources:
+                num_cpu = resources["CPU"]
+                resources.pop("CPU", None)
             self._spark_master_handle = RayDPSparkMaster.options(name=spark_master_name,
                                                                  num_cpus=num_cpu,
                                                                  resources=resources) \
@@ -59,7 +59,7 @@ class SparkCluster(Cluster):
 
     def _get_master_resources(self, configs: Dict[str, str]) -> Dict[str, float]:
         resources = {}
-        object_holder_config_prefix = 'spark.ray.raydp_spark_master.resource.'
+        object_holder_config_prefix = "spark.ray.raydp_spark_master.resource."
         for key in configs:
             if key.startswith(object_holder_config_prefix):
                 resource_name = key[len(object_holder_config_prefix):]

--- a/python/raydp/spark/ray_cluster.py
+++ b/python/raydp/spark/ray_cluster.py
@@ -35,15 +35,37 @@ class SparkCluster(Cluster):
         self._app_name = app_name
         self._spark_master_handle = None
         self._configs = configs
-        self._set_up_master(None, None)
+        self._set_up_master(resources=self._get_master_resources(configs), kwargs=None)
         self._spark_session: SparkSession = None
 
     def _set_up_master(self, resources: Dict[str, float], kwargs: Dict[Any, Any]):
         # TODO: specify the app master resource
         spark_master_name = self._app_name + RAYDP_SPARK_MASTER_SUFFIX
-        self._spark_master_handle = RayDPSparkMaster.options(name=spark_master_name) \
-                                                    .remote(self._configs)
+
+        if resources:
+            num_cpu = 1
+            if 'CPU' in resources:
+                num_cpu = resources['CPU']
+                resources.pop('CPU', None)
+            self._spark_master_handle = RayDPSparkMaster.options(name=spark_master_name,
+                                                                 num_cpus=num_cpu,
+                                                                 resources=resources) \
+                                                        .remote(self._configs)
+        else:
+            self._spark_master_handle = RayDPSparkMaster.options(name=spark_master_name) \
+                .remote(self._configs)
+
         ray.get(self._spark_master_handle.start_up.remote())
+
+    def _get_master_resources(self, configs: Dict[str, str]) -> Dict[str, float]:
+        resources = {}
+        object_holder_config_prefix = 'spark.ray.raydp_spark_master.resource.'
+        for key in configs:
+            if key.startswith(object_holder_config_prefix):
+                resource_name = key[len(object_holder_config_prefix):]
+                resources[resource_name] = float(configs[key])
+
+        return resources
 
     def _set_up_worker(self, resources: Dict[str, float], kwargs: Dict[str, str]):
         raise Exception("Unsupported operation")

--- a/python/raydp/spark/ray_cluster.py
+++ b/python/raydp/spark/ray_cluster.py
@@ -59,10 +59,10 @@ class SparkCluster(Cluster):
 
     def _get_master_resources(self, configs: Dict[str, str]) -> Dict[str, float]:
         resources = {}
-        object_holder_config_prefix = "spark.ray.raydp_spark_master.resource."
+        spark_master_config_prefix = "spark.ray.raydp_spark_master.resource."
         for key in configs:
-            if key.startswith(object_holder_config_prefix):
-                resource_name = key[len(object_holder_config_prefix):]
+            if key.startswith(spark_master_config_prefix):
+                resource_name = key[len(spark_master_config_prefix):]
                 resources[resource_name] = float(configs[key])
 
         return resources


### PR DESCRIPTION
### What Problem Does this PR Solve
By default the `SPARK_MASTER` and `OBJ_HOLDER` actor could be placed at any node -- This is not a problem when you have a large head node, or all nodes are on demand in the cluster. However in our production setup, we are using small head node with spot machines as workers. Spark master will get launch on worker nodes and when we get spot kill the driver died and the job hang.

To solve this problem, we need a way to do node affinity: We need a way to force the Spark driver (or any other critical Spark actor infrastructure) to land on stable machines that is defined by users.

### Purposed Solution

Add a extra config in raydp python API for both Spark master so user can place them to nodes with resources specified:
```
spark.ray.raydp_spark_master.resource.*
```

Example usage:

```python
raydp.init_spark(...,
configs = {
    # ... other configs
    'spark.ray.raydp_spark_master.resource.CPU': 0,
    'spark.ray.raydp_spark_master.resource.spark_master': 1,  # Force Spark driver related actor run on headnode
})
```

In cluster config yaml:
```yaml
available_node_types:
  ray.head.default:
    resources:
      CPU: 0    # We intentionally set this to 0 so not executors are on headnode
      spark_master: 100  # Just gave it a large enough number so all drivers are there
```