### PR TITLE
Merge the function of Object Holder into RayDPSparkMaster

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,9 @@ ds1 = ray.data.from_spark(df1)
 ds2 = ray.data.from_items([{"id": i} for i in range(1000)])
 df2 = ds2.to_spark(spark)
 ```
+
+Ray dataset converted from Spark dataframe this way will be no longer accessible after `raydp.stop_spark()`. If you want to access the data after spark is shutdown, please use `raydp.stop_spark(cleanup_data=False)`. 
+
 Please refer to [Spark+XGBoost on Ray](./examples/xgboost_ray_nyctaxi.py) for a full example.
 
 ***Estimator API***

--- a/python/raydp/context.py
+++ b/python/raydp/context.py
@@ -119,13 +119,13 @@ class _SparkContext(ContextDecorator):
             self._configs)
         return self._spark_session
 
-    def stop(self, del_obj_holder=True):
+    def stop(self, cleanup_data=True):
         if self._spark_session is not None:
             self._spark_session.stop()
             self._spark_session = None
         if self._spark_cluster is not None:
-            self._spark_cluster.stop(del_obj_holder)
-            if del_obj_holder:
+            self._spark_cluster.stop(cleanup_data)
+            if cleanup_data:
                 self._spark_cluster = None
         if self._placement_group_strategy is not None:
             if self._placement_group is not None:
@@ -202,12 +202,12 @@ def init_spark(app_name: str,
             raise Exception("The spark environment has inited.")
 
 
-def stop_spark(del_obj_holder=True):
+def stop_spark(cleanup_data=True):
     with _spark_context_lock:
         global _global_spark_context
         if _global_spark_context is not None:
-            _global_spark_context.stop(del_obj_holder)
-            if del_obj_holder is True:
+            _global_spark_context.stop(cleanup_data)
+            if cleanup_data is True:
                 _global_spark_context = None
 
 

--- a/python/raydp/context.py
+++ b/python/raydp/context.py
@@ -26,7 +26,6 @@ from pyspark.sql import SparkSession
 from ray.util.placement_group import PlacementGroup
 
 from raydp.spark import SparkCluster
-from raydp.spark.dataset import RayDPConversionHelper, RAYDP_OBJ_HOLDER_SUFFIX
 from raydp.utils import parse_memory_size
 
 
@@ -109,8 +108,6 @@ class _SparkContext(ContextDecorator):
     def get_or_create_session(self):
         if self._spark_session is not None:
             return self._spark_session
-        obj_holder_name = self._app_name + RAYDP_OBJ_HOLDER_SUFFIX
-        self.handle = RayDPConversionHelper.options(name=obj_holder_name).remote()
         self._prepare_placement_group()
         spark_cluster = self._get_or_create_spark_cluster()
         self._spark_session = spark_cluster.get_spark_session(
@@ -126,12 +123,10 @@ class _SparkContext(ContextDecorator):
         if self._spark_session is not None:
             self._spark_session.stop()
             self._spark_session = None
-        if self.handle is not None and del_obj_holder is True:
-            self.handle.terminate.remote()
-            self.handle = None
         if self._spark_cluster is not None:
-            self._spark_cluster.stop()
-            self._spark_cluster = None
+            self._spark_cluster.stop(del_obj_holder)
+            if del_obj_holder:
+                self._spark_cluster = None
         if self._placement_group_strategy is not None:
             if self._placement_group is not None:
                 ray.util.remove_placement_group(self._placement_group)

--- a/python/raydp/spark/ray_cluster.py
+++ b/python/raydp/spark/ray_cluster.py
@@ -106,11 +106,12 @@ class SparkCluster(Cluster):
             spark_builder.appName(app_name).master(self.get_cluster_url()).getOrCreate()
         return self._spark_session
 
-    def stop(self):
+    def stop(self, del_obj_holder):
         if self._spark_session is not None:
             self._spark_session.stop()
             self._spark_session = None
 
         if self._spark_master_handle is not None:
-            self._spark_master_handle.stop.remote()
-            self._spark_master_handle = None
+            self._spark_master_handle.stop.remote(del_obj_holder)
+            if del_obj_holder:
+                self._spark_master_handle = None

--- a/python/raydp/spark/ray_cluster.py
+++ b/python/raydp/spark/ray_cluster.py
@@ -106,12 +106,12 @@ class SparkCluster(Cluster):
             spark_builder.appName(app_name).master(self.get_cluster_url()).getOrCreate()
         return self._spark_session
 
-    def stop(self, del_obj_holder):
+    def stop(self, cleanup_data):
         if self._spark_session is not None:
             self._spark_session.stop()
             self._spark_session = None
 
         if self._spark_master_handle is not None:
-            self._spark_master_handle.stop.remote(del_obj_holder)
-            if del_obj_holder:
+            self._spark_master_handle.stop.remote(cleanup_data)
+            if cleanup_data:
                 self._spark_master_handle = None

--- a/python/raydp/spark/ray_cluster_master.py
+++ b/python/raydp/spark/ray_cluster_master.py
@@ -200,7 +200,7 @@ class RayDPSparkMaster():
             self._actor_id = ray.get_runtime_context().actor_id
         return self._actor_id
 
-    def stop(self, del_obj_holder):
+    def stop(self, cleanup_data):
         self._started_up = False
         if self._app_master_java_bridge is not None:
             self._app_master_java_bridge.stop()
@@ -210,5 +210,5 @@ class RayDPSparkMaster():
             self._gateway.shutdown()
             self._gateway.proc.terminate()
             self._gateway = None
-        if del_obj_holder:
+        if cleanup_data:
             ray.actor.exit_actor()

--- a/python/raydp/spark/ray_cluster_master.py
+++ b/python/raydp/spark/ray_cluster_master.py
@@ -185,7 +185,7 @@ class RayDPSparkMaster():
     def get_spark_home(self) -> str:
         assert self._started_up
         return self._spark_home
-    
+
     def add_objects(self, timestamp, objects):
         self._objects[timestamp] = objects
 

--- a/python/raydp/tests/test_data_owner_transfer.py
+++ b/python/raydp/tests/test_data_owner_transfer.py
@@ -109,7 +109,7 @@ def test_data_ownership_transfer(ray_cluster):
   ds.show(5)
 
   # release resource by shutting down spark Java process
-  raydp.stop_spark(del_obj_holder=False)
+  raydp.stop_spark(cleanup_data=False)
   ray_gc() # ensure GC kicked in
   time.sleep(3)
 

--- a/python/raydp/tf/estimator.py
+++ b/python/raydp/tf/estimator.py
@@ -264,7 +264,7 @@ class TFEstimator(EstimatorInterface, SparkEstimatorInterface):
                 evaluate_ds = spark_dataframe_to_ray_dataset(evaluate_df,
                                                          _use_owner=stop_spark_after_conversion)
         if stop_spark_after_conversion:
-            stop_spark(del_obj_holder=False)
+            stop_spark(cleanup_data=False)
         return self.fit(
             train_ds, evaluate_ds, max_retries)
 

--- a/python/raydp/torch/estimator.py
+++ b/python/raydp/torch/estimator.py
@@ -358,7 +358,7 @@ class TorchEstimator(EstimatorInterface, SparkEstimatorInterface):
                                                          parallelism=self._num_workers,
                                                          _use_owner=stop_spark_after_conversion)
         if stop_spark_after_conversion:
-            stop_spark(del_obj_holder=False)
+            stop_spark(cleanup_data=False)
         return self.fit(
             train_ds, evaluate_ds, max_retries)
 


### PR DESCRIPTION
Object holder is added when RayDPSparkMaster is not an actor. Now that we already have an actor at driver node, we can merge the object holding function into it.