### PR TITLE
Add an estimator API for XGBoost using Ray's XGBoostTrainer

### DIFF
--- a/.github/workflows/raydp.yml
+++ b/.github/workflows/raydp.yml
@@ -101,8 +101,9 @@ jobs:
       - name: Test with pytest
         run: |
           ray start --head --num-cpus 6
-          pytest python/raydp/tests/ -m"not error_on_custom_resource"
-          pytest python/raydp/tests/ -m"error_on_custom_resource"
+          python python/raydp/tests/test_xgboost.py
+          # pytest python/raydp/tests/ -m"not error_on_custom_resource"
+          # pytest python/raydp/tests/ -m"error_on_custom_resource"
           ray stop --force
       - name: Test Examples
         run: |

--- a/.github/workflows/raydp.yml
+++ b/.github/workflows/raydp.yml
@@ -104,7 +104,6 @@ jobs:
           ray start --head --num-cpus 6
           pytest python/raydp/tests/ -v -m"not error_on_custom_resource"
           pytest python/raydp/tests/ -v -m"error_on_custom_resource"
-          cat /tmp/ray/session_latest/logs/*
           ray stop --force
       - name: Test Examples
         run: |

--- a/.github/workflows/raydp.yml
+++ b/.github/workflows/raydp.yml
@@ -102,8 +102,9 @@ jobs:
       - name: Test with pytest
         run: |
           ray start --head --num-cpus 6
-          pytest python/raydp/tests/ -m"not error_on_custom_resource"
-          pytest python/raydp/tests/ -m"error_on_custom_resource"
+          pytest python/raydp/tests/ -v -m"not error_on_custom_resource"
+          pytest python/raydp/tests/ -v -m"error_on_custom_resource"
+          cat /tmp/ray/session_latest/logs/*
           ray stop --force
       - name: Test Examples
         run: |

--- a/.github/workflows/raydp.yml
+++ b/.github/workflows/raydp.yml
@@ -101,9 +101,8 @@ jobs:
       - name: Test with pytest
         run: |
           ray start --head --num-cpus 6
-          python python/raydp/tests/test_xgboost.py
-          # pytest python/raydp/tests/ -m"not error_on_custom_resource"
-          # pytest python/raydp/tests/ -m"error_on_custom_resource"
+          pytest python/raydp/tests/ -m"not error_on_custom_resource"
+          pytest python/raydp/tests/ -m"error_on_custom_resource"
           ray stop --force
       - name: Test Examples
         run: |

--- a/python/raydp/tests/test_mpi.py
+++ b/python/raydp/tests/test_mpi.py
@@ -16,7 +16,7 @@
 #
 
 import sys
-
+import platform
 import pytest
 import ray
 import ray._private.services
@@ -27,6 +27,8 @@ from raydp.mpi import create_mpi_job, MPIJobContext, WorkerContext
 
 @pytest.mark.timeout(10)
 def test_mpi_start(ray_cluster):
+    if platform.system() == "Darwin":
+        pytest.skip("Skip MPI test on MacOS")
     if not ray.worker.global_worker.connected:
         pytest.skip("Skip MPI test if using ray client")
     job = create_mpi_job(job_name="test",
@@ -58,6 +60,8 @@ def test_mpi_start(ray_cluster):
 
 @pytest.mark.timeout(10)
 def test_mpi_get_rank_address(ray_cluster):
+    if platform.system() == "Darwin":
+        pytest.skip("Skip MPI test on MacOS")
     if not ray.worker.global_worker.connected:
         pytest.skip("Skip MPI test if using ray client")
     with create_mpi_job(job_name="test",
@@ -74,6 +78,8 @@ def test_mpi_get_rank_address(ray_cluster):
 
 
 def test_mpi_with_script_prepare_fn(ray_cluster):
+    if platform.system() == "Darwin":
+        pytest.skip("Skip MPI test on MacOS")
     if not ray.worker.global_worker.connected:
         pytest.skip("Skip MPI test if using ray client")
     def script_prepare_fn(context: MPIJobContext):
@@ -99,6 +105,8 @@ def test_mpi_with_script_prepare_fn(ray_cluster):
 
 
 def test_mpi_with_pg(ray_cluster):
+    if platform.system() == "Darwin":
+        pytest.skip("Skip MPI test on MacOS")
     if not ray.worker.global_worker.connected:
         pytest.skip("Skip MPI test if using ray client")
     pg = placement_group(bundles=[{"CPU": 2}], strategy="STRICT_SPREAD")

--- a/python/raydp/tests/test_xgboost.py
+++ b/python/raydp/tests/test_xgboost.py
@@ -18,6 +18,7 @@
 import os
 import sys
 import shutil
+import platform
 import pytest
 import pyspark
 import numpy as np
@@ -28,6 +29,8 @@ from raydp.utils import random_split
 
 @pytest.mark.parametrize("use_fs_directory", [True, False])
 def test_xgb_estimator(spark_on_ray_small, use_fs_directory):
+    if platform.system() == "Darwin":
+        pytest.skip("Skip MPI test on MacOS")
     spark = spark_on_ray_small
 
     # calculate z = 3 * x + 4 * y + 5

--- a/python/raydp/tests/test_xgboost.py
+++ b/python/raydp/tests/test_xgboost.py
@@ -54,4 +54,4 @@ if __name__ == '__main__':
     import ray, raydp
     ray.init(address="auto")
     spark = raydp.init_spark('test_xgboost', 1, 1, '500m')
-    test_xgb_estimator(spark, False)
+    test_xgb_estimator(spark, True)

--- a/python/raydp/tests/test_xgboost.py
+++ b/python/raydp/tests/test_xgboost.py
@@ -1,0 +1,44 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import pytest
+import databricks.koalas as ks
+
+from raydp.xgboost import XGBoostEstimator
+from raydp.utils import random_split
+
+@pytest.mark.parametrize("use_fs_directory", [True, False])
+def test_xgb_estimator(spark_on_ray_small, use_fs_directory):
+    spark = spark_on_ray_small
+
+    # calculate z = 3 * x + 4 * y + 5
+    df: ks.DataFrame = ks.range(0, 100000)
+    df["x"] = df["id"] + 100
+    df["y"] = df["id"] + 1000
+    df["z"] = df["x"] * 3 + df["y"] * 4 + 5
+    df = df.astype("float")
+
+    train_df, test_df = random_split(df, [0.7, 0.3])
+    params = {}
+    estimator = XGBoostEstimator(params, "z", resources_per_worker={"CPU": 1})
+    estimator.fit_on_spark(train_df=train_df, evaluate_df=test_df)
+
+if __name__ == '__main__':
+    import ray, raydp
+    ray.init()
+    spark = raydp.init_spark('a', 1, 1, '500m')
+    test_xgb_estimator(spark, False)

--- a/python/raydp/tests/test_xgboost.py
+++ b/python/raydp/tests/test_xgboost.py
@@ -51,4 +51,7 @@ def test_xgb_estimator(spark_on_ray_small, use_fs_directory):
         shutil.rmtree(dir)
 
 if __name__ == '__main__':
-    sys.exit(pytest.main(["-v", __file__]))
+    import ray, raydp
+    ray.init(address="auto")
+    spark = raydp.init_spark('test_xgboost', 1, 1, '500m')
+    test_xgb_estimator(spark, False)

--- a/python/raydp/tests/test_xgboost.py
+++ b/python/raydp/tests/test_xgboost.py
@@ -41,7 +41,7 @@ def test_xgb_estimator(spark_on_ray_small, use_fs_directory):
     params = {}
     estimator = XGBoostEstimator(params, "z", resources_per_worker={"CPU": 1})
     if use_fs_directory:
-        dir = os.path.dirname(__file__) + "/test_tf"
+        dir = os.path.dirname(os.path.realpath(__file__)) + "/test_xgboost"
         uri = "file://" + dir
         estimator.fit_on_spark(train_df, test_df, fs_directory=uri)
     else:

--- a/python/raydp/xgboost/__init__.py
+++ b/python/raydp/xgboost/__init__.py
@@ -1,0 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from .estimator import XGBoostEstimator
+
+__all__ = ["XGBoostEstimator"]

--- a/python/raydp/xgboost/estimator.py
+++ b/python/raydp/xgboost/estimator.py
@@ -1,0 +1,116 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from typing import Any, Callable, List, NoReturn, Optional, Union, Dict
+
+from raydp.estimator import EstimatorInterface
+from raydp.spark.interfaces import SparkEstimatorInterface, DF, OPTIONAL_DF
+from raydp import stop_spark
+from raydp.spark import spark_dataframe_to_ray_dataset
+
+import ray
+from ray.air.config import ScalingConfig, RunConfig, FailureConfig
+from ray.data.dataset import Dataset
+from ray.train.xgboost import XGBoostTrainer, XGBoostCheckpoint
+
+class XGBoostEstimator(EstimatorInterface, SparkEstimatorInterface):
+    def __init__(self,
+                 xgboost_params: Dict,
+                 label_column: str,
+                 dmatrix_params: Dict = None,
+                 num_workers: int = 1,
+                 resources_per_worker: Optional[Dict[str, float]] = None,
+                 shuffle: bool = True):
+        """
+        :param xgboost_params: XGBoost training parameters.
+              Refer to `XGBoost documentation <https://xgboost.readthedocs.io/>`_
+              for a list of possible parameters.
+        :param label_column: Name of the label column. A column with this name
+              must be present in the training dataset passed to fit() later.
+        :param dmatrix_params: Dict of ``dataset name:dict of kwargs`` passed to respective
+              :class:`xgboost_ray.RayDMatrix` initializations, which in turn are passed
+              to ``xgboost.DMatrix`` objects created on each worker. For example, this can
+              be used to add sample weights with the ``weights`` parameter.
+        :param num_workers: the number of workers to do the distributed training.
+        :param resources_per_worker: the resources defined in this Dict will be reserved for
+              each worker. The ``CPU`` and ``GPU`` keys (case-sensitive) can be defined to
+              override the number of CPU/GPUs used by each worker.
+        :param shuffle: whether to shuffle the data
+        """
+        self._xgboost_params = xgboost_params
+        self._label_column = label_column
+        self._dmatrix_params = dmatrix_params
+        self._num_workers = num_workers
+        self._resources_per_worker = resources_per_worker
+        self._shuffle = shuffle
+
+    def fit(self,
+            train_ds: Dataset,
+            evaluate_ds: Optional[Dataset] = None,
+            max_retries=3) -> NoReturn:
+        scaling_config = ScalingConfig(num_workers=self._num_workers,
+                                      resources_per_worker=self._resources_per_worker)
+        run_config = RunConfig(failure_config=FailureConfig(max_failures=max_retries))
+        if self._shuffle:
+            train_ds = train_ds.random_shuffle()
+            if evaluate_ds:
+                evaluate_ds = evaluate_ds.random_shuffle()
+        datasets = {"train": train_ds}
+        if evaluate_ds:
+            datasets["evaluate"] = evaluate_ds
+        trainer = XGBoostTrainer(scaling_config=scaling_config,
+                                datasets=datasets,
+                                label_column=self._label_column,
+                                params=self._xgboost_params,
+                                dmatrix_params=self._dmatrix_params,
+                                run_config=run_config)
+        self._results = trainer.fit()
+
+    def fit_on_spark(self,
+                     train_df: DF,
+                     evaluate_df: OPTIONAL_DF = None,
+                     max_retries=3,
+                     fs_directory: Optional[str] = None,
+                     compression: Optional[str] = None,
+                     stop_spark_after_conversion=False):
+        train_df = self._check_and_convert(train_df)
+        evaluate_ds = None
+        if fs_directory is not None:
+            app_id = train_df.sql_ctx.sparkSession.sparkContext.applicationId
+            path = fs_directory.rstrip("/") + f"/{app_id}"
+            train_df.write.parquet(path+"/train", compression=compression)
+            train_ds = ray.data.read_parquet(path+"/train")
+            if evaluate_df is not None:
+                evaluate_df = self._check_and_convert(evaluate_df)
+                evaluate_df.write.parquet(path+"/test", compression=compression)
+                evaluate_ds = ray.data.read_parquet(path+"/test")
+        else:
+            train_ds = spark_dataframe_to_ray_dataset(train_df,
+                                                  parallelism=self._num_workers,
+                                                  _use_owner=stop_spark_after_conversion)
+            if evaluate_df is not None:
+                evaluate_df = self._check_and_convert(evaluate_df)
+                evaluate_ds = spark_dataframe_to_ray_dataset(evaluate_df,
+                                                         parallelism=self._num_workers,
+                                                         _use_owner=stop_spark_after_conversion)
+        if stop_spark_after_conversion:
+            stop_spark(cleanup_data=False)
+        return self.fit(
+            train_ds, evaluate_ds, max_retries)
+
+    def get_model(self):
+        return XGBoostCheckpoint.from_checkpoint(self._results.checkpoint).get_model()


### PR DESCRIPTION
We now have 2 estimators, for tensorflow and pytorch. This PR adds another one for xgboost. The XGBoostTrianer's interface is already simple, and our estimator adds an function to work on spark dataframes.