### PR TITLE
Bump to 1.6.0

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.intel</groupId>
   <artifactId>raydp-parent</artifactId>
-  <version>0.7.0-SNAPSHOT</version>
+  <version>1.6.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>RayDP Parent Pom</name>

--- a/core/raydp-main/pom.xml
+++ b/core/raydp-main/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.intel</groupId>
     <artifactId>raydp-parent</artifactId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>1.6.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/core/shims/common/pom.xml
+++ b/core/shims/common/pom.xml
@@ -7,13 +7,13 @@
   <parent>
     <groupId>com.intel</groupId>
     <artifactId>raydp-shims</artifactId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>1.6.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>raydp-shims-common</artifactId>
   <name>RayDP Shims Common</name>
-  <version>0.7.0-SNAPSHOT</version>
+  <version>1.6.0-SNAPSHOT</version>
   <packaging>jar</packaging>
   
   <build>

--- a/core/shims/pom.xml
+++ b/core/shims/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.intel</groupId>
     <artifactId>raydp-parent</artifactId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>1.6.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/core/shims/spark321/pom.xml
+++ b/core/shims/spark321/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.intel</groupId>
     <artifactId>raydp-shims</artifactId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>1.6.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/core/shims/spark330/pom.xml
+++ b/core/shims/spark330/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.intel</groupId>
     <artifactId>raydp-shims</artifactId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>1.6.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/python/raydp/__init__.py
+++ b/python/raydp/__init__.py
@@ -17,6 +17,6 @@
 
 from raydp.context import init_spark, stop_spark
 
-__version__ = "0.7.0.dev0"
+__version__ = "1.6.0.dev0"
 
 __all__ = ["init_spark", "stop_spark"]

--- a/python/setup.py
+++ b/python/setup.py
@@ -29,7 +29,7 @@ package_name = os.getenv("RAYDP_PACKAGE_NAME", "raydp")
 if package_name == 'raydp_nightly':
     VERSION = datetime.today().strftime("%Y.%m.%d.dev1")
 else:
-    VERSION = "0.7.0.dev0"
+    VERSION = "1.6.0.dev0"
 
 ROOT_DIR = os.path.dirname(__file__)
 


### PR DESCRIPTION
To align with the OAP project release version, bump to 1.6.0. 