### PR TITLE
Update setup.py to not depend on `typing.py` backport

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -90,7 +90,6 @@ try:
 
     install_requires = [
         "numpy",
-        "typing",
         "pandas >= 1.1.4",
         "psutil",
         "pyarrow >= 4.0.1",


### PR DESCRIPTION
The typing library lives in the standard library as of python 3.5, but there is a [backport](https://pypi.org/project/typing/) on pypi which allows you to use typing in even earlier versions of python. The docs of the backport say this:

> NOTE: in Python 3.5 and later, the typing module lives in the stdlib, and installing this package has NO EFFECT, because stdlib takes higher precedence than the installation directory. To get a newer version of the typing module in Python 3.5 or later, you have to upgrade to a newer Python (bugfix) version. For example, typing in Python 3.6.0 is missing the definition of ‘Type’ – upgrading to 3.6.2 will fix this.

However, this assumes some things about your build system/python environment that may be violated in some cases ([for example](https://stackoverflow.com/questions/75262818/avoid-transitive-dependency-on-python-typing-backport), when using a python env managed by bazel).

Given that new releases of raydp only support python 3.6 and above, relying on the stdlib typing should be sufficient and it should be safe to remove this dependency on the backport.