### PR TITLE
When converting spark df to ray dataset, you can choose whether to release the resources requested by spark

### DIFF
--- a/python/raydp/spark/dataset.py
+++ b/python/raydp/spark/dataset.py
@@ -161,7 +161,7 @@ def _save_spark_df_to_object_store(df: sql.DataFrame, use_batch: bool = True,
     record_tuples = [(record.objectId(), record.ownerAddress(), record.numRecords())
                         for record in records]
     blocks, block_sizes = _register_objects(record_tuples)
-    if recover_ray_resource_from_spark:
+    if recover_ray_resources_from_spark:
         df.sql_ctx.sparkSession.stop()
     if _use_owner is True:
         holder = ray.get_actor(obj_holder_name)

--- a/python/raydp/spark/dataset.py
+++ b/python/raydp/spark/dataset.py
@@ -173,13 +173,13 @@ def _save_spark_df_to_object_store(df: sql.DataFrame, use_batch: bool = True,
 
 def spark_dataframe_to_ray_dataset(df: sql.DataFrame,
                                    parallelism: Optional[int] = None,
-                                   _use_owner: bool = False, 
+                                   _use_owner: bool = False,
                                    recover_ray_resources_from_spark=False):
     num_part = df.rdd.getNumPartitions()
     if parallelism is not None:
         if parallelism != num_part:
             df = df.repartition(parallelism)
-    blocks, _ = _save_spark_df_to_object_store(df, False, _use_owner, 
+    blocks, _ = _save_spark_df_to_object_store(df, False, _use_owner,
                                                recover_ray_resources_from_spark)
     return from_arrow_refs(blocks)
 

--- a/python/raydp/spark/dataset.py
+++ b/python/raydp/spark/dataset.py
@@ -172,12 +172,12 @@ def _save_spark_df_to_object_store(df: sql.DataFrame, use_batch: bool = True,
 
 def spark_dataframe_to_ray_dataset(df: sql.DataFrame,
                                    parallelism: Optional[int] = None,
-                                   _use_owner: bool = False):
+                                   _use_owner: bool = False, recover_ray_resources_from_spark=False):
     num_part = df.rdd.getNumPartitions()
     if parallelism is not None:
         if parallelism != num_part:
             df = df.repartition(parallelism)
-    blocks, _ = _save_spark_df_to_object_store(df, False, _use_owner)
+    blocks, _ = _save_spark_df_to_object_store(df, False, _use_owner, recover_ray_resources_from_spark)
     return from_arrow_refs(blocks)
 
 # This is an experimental API for now.

--- a/python/raydp/spark/dataset.py
+++ b/python/raydp/spark/dataset.py
@@ -147,7 +147,8 @@ def _register_objects(records):
     return blocks, block_sizes
 
 def _save_spark_df_to_object_store(df: sql.DataFrame, use_batch: bool = True,
-                                   _use_owner: bool = False, recover_ray_resources_from_spark=False):
+                                   _use_owner: bool = False,
+                                   recover_ray_resources_from_spark=False):
     # call java function from python
     jvm = df.sql_ctx.sparkSession.sparkContext._jvm
     jdf = df._jdf
@@ -172,12 +173,14 @@ def _save_spark_df_to_object_store(df: sql.DataFrame, use_batch: bool = True,
 
 def spark_dataframe_to_ray_dataset(df: sql.DataFrame,
                                    parallelism: Optional[int] = None,
-                                   _use_owner: bool = False, recover_ray_resources_from_spark=False):
+                                   _use_owner: bool = False, 
+                                   recover_ray_resources_from_spark=False):
     num_part = df.rdd.getNumPartitions()
     if parallelism is not None:
         if parallelism != num_part:
             df = df.repartition(parallelism)
-    blocks, _ = _save_spark_df_to_object_store(df, False, _use_owner, recover_ray_resources_from_spark)
+    blocks, _ = _save_spark_df_to_object_store(df, False, _use_owner, 
+                                               recover_ray_resources_from_spark)
     return from_arrow_refs(blocks)
 
 # This is an experimental API for now.

--- a/python/raydp/spark/dataset.py
+++ b/python/raydp/spark/dataset.py
@@ -147,7 +147,7 @@ def _register_objects(records):
     return blocks, block_sizes
 
 def _save_spark_df_to_object_store(df: sql.DataFrame, use_batch: bool = True,
-                                   _use_owner: bool = False):
+                                   _use_owner: bool = False, recover_ray_resources_from_spark=False):
     # call java function from python
     jvm = df.sql_ctx.sparkSession.sparkContext._jvm
     jdf = df._jdf
@@ -161,7 +161,8 @@ def _save_spark_df_to_object_store(df: sql.DataFrame, use_batch: bool = True,
     record_tuples = [(record.objectId(), record.ownerAddress(), record.numRecords())
                         for record in records]
     blocks, block_sizes = _register_objects(record_tuples)
-
+    if recover_ray_resource_from_spark:
+        df.sql_ctx.sparkSession.stop()
     if _use_owner is True:
         holder = ray.get_actor(obj_holder_name)
         df_id = uuid.uuid4()

--- a/python/raydp/tests/test_spark_to_dataset_recover_spark.py
+++ b/python/raydp/tests/test_spark_to_dataset_recover_spark.py
@@ -7,7 +7,7 @@ from ray.data._internal.arrow_block import ArrowRow
 
 
 def from_spark(
-    df: "pyspark.sql.DataFrame", *,parallelism: Optional[int] = None
+    df: "pyspark.sql.DataFrame", *,parallelism: Optional[int] = None,
     recover_ray_resources_from_spark=False
 ) -> Dataset[ArrowRow]:
     """Create a dataset from a Spark dataframe.

--- a/python/raydp/tests/test_spark_to_dataset_recover_spark.py
+++ b/python/raydp/tests/test_spark_to_dataset_recover_spark.py
@@ -39,6 +39,14 @@ df1 = spark.range(0, 1000)
 raydp.stop_spark(False)
 ds1 = from_spark(df1, recover_ray_resources_from_spark=True)
 
+# reinit spark
+
+spark = raydp.init_spark(app_name="RayDP Example1",
+                         num_executors=2,
+                         executor_cores=2,
+                         executor_memory="4G")
+
+
 # Ray Dataset to Spark Dataframe
 ds2 = ray.data.from_items([{"id": i} for i in range(1000)])
 df2 = ds2.to_spark(spark)

--- a/python/raydp/tests/test_spark_to_dataset_recover_spark.py
+++ b/python/raydp/tests/test_spark_to_dataset_recover_spark.py
@@ -25,38 +25,39 @@ def from_spark(
     return raydp.spark.spark_dataframe_to_ray_dataset(df,
                                                       parallelism,
                                                       recover_ray_resources_from_spark=recover_ray_resources_from_spark)
+def test_():
+    
+    ray.init()
+    init_resources = ray.available_resources()
+    spark = raydp.init_spark(app_name="RayDP Example",
+                             num_executors=1,
+                             executor_cores=1,
+                             executor_memory="500M")
+    init_spark_resources = ray.available_resources()
+    assert (init_resources["CPU"] - init_spark_resources["CPU"]) == 1.0 
+    assert (init_resources["memory"] - init_spark_resources["memory"]) == 524288000.0
+    # Spark Dataframe to Ray Dataset
+    df1 = spark.range(0, 1000)
+    
+    ds1 = from_spark(df1, recover_ray_resources_from_spark=True)
+    
+    recover_ray_resources = ray.available_resources()
+    assert (recover_ray_resources["CPU"] - init_spark_resources["CPU"]) == 1.0 
+    assert (recover_ray_resources["memory"] - init_spark_resources["memory"]) == 524288000.0
+    
+    raydp.stop_spark(True)
+    stop_spark_resources = ray.available_resources()
+    assert (stop_spark_resources["CPU"] - init_spark_resources["CPU"]) == 1.0 
+    assert (stop_spark_resources["memory"] - init_spark_resources["memory"]) == 524288000.0
+    
+    # reinit spark
+    spark = raydp.init_spark(app_name="RayDP Example1",
+                             num_executors=1,
+                             executor_cores=1,
+                             executor_memory="500M")
 
-ray.init()
-spark = raydp.init_spark(app_name="RayDP Example",
-                         num_executors=2,
-                         executor_cores=2,
-                         executor_memory="4G")
+    # Ray Dataset to Spark Dataframe
+    ds2 = ray.data.from_items([{"id": i} for i in range(1000)])
+    df2 = ds2.to_spark(spark)
+    
 
-
-
-# Spark Dataframe to Ray Dataset
-df1 = spark.range(0, 1000)
-raydp.stop_spark(False)
-ds1 = from_spark(df1, recover_ray_resources_from_spark=True)
-
-# reinit spark
-
-spark = raydp.init_spark(app_name="RayDP Example1",
-                         num_executors=2,
-                         executor_cores=2,
-                         executor_memory="4G")
-
-
-# Ray Dataset to Spark Dataframe
-ds2 = ray.data.from_items([{"id": i} for i in range(1000)])
-df2 = ds2.to_spark(spark)
-
-
-"""
-my run res is:
-after init spark, ray available_resources is:  {'CPU': 2.0, 'memory': 2920706458.0, 'node:127.0.0.1': 1.0, 'object_store_memory': 2147483648.0}
-after convert spark df to ray dataset(use recover_ray_resources_from_spark is True),ray available_resources is:  {'CPU': 3.0, 'object_store_memory': 2147483648.0, 'node:127.0.0.1': 1.0, 'memory': 7215673754.0}
-after call raydp.stop_spark, ray available_resources is:  {'CPU': 4.0, 'memory': 7215673754.0, 'node:127.0.0.1': 1.0, 'object_store_memory': 2147483648.0}
-
-It can be seen that after adding the parameter recover_ray_resources_from_spark, the resources are indeed released
-"""

--- a/python/raydp/tests/test_spark_to_dataset_recover_spark.py
+++ b/python/raydp/tests/test_spark_to_dataset_recover_spark.py
@@ -60,4 +60,5 @@ def test_():
     ds2 = ray.data.from_items([{"id": i} for i in range(1000)])
     df2 = ds2.to_spark(spark)
     
-
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", __file__]))

--- a/python/raydp/tests/test_spark_to_dataset_recover_spark.py
+++ b/python/raydp/tests/test_spark_to_dataset_recover_spark.py
@@ -1,18 +1,43 @@
+from typing import Optional
+
 import ray
 import raydp
+from ray.data import Dataset
+from ray.data._internal.arrow_block import ArrowRow
+
+
+def from_spark(
+    df: "pyspark.sql.DataFrame", *,parallelism: Optional[int] = None
+    recover_ray_resources_from_spark=False
+) -> Dataset[ArrowRow]:
+    """Create a dataset from a Spark dataframe.
+    Args:
+        spark: A SparkSession, which must be created by RayDP (Spark-on-Ray).
+        df: A Spark dataframe, which must be created by RayDP (Spark-on-Ray).
+            parallelism: The amount of parallelism to use for the dataset.
+            If not provided, it will be equal to the number of partitions of
+            the original Spark dataframe.
+    Returns:
+        Dataset holding Arrow records read from the dataframe.
+    """
+    import raydp
+
+    return raydp.spark.spark_dataframe_to_ray_dataset(df,
+                                                      parallelism,
+                                                      recover_ray_resources_from_spark=recover_ray_resources_from_spark)
 
 ray.init()
 spark = raydp.init_spark(app_name="RayDP Example",
                          num_executors=2,
                          executor_cores=2,
-                         executor_memory="4GB")
+                         executor_memory="4G")
 
 
 
 # Spark Dataframe to Ray Dataset
 df1 = spark.range(0, 1000)
 raydp.stop_spark(False)
-ds1 = ray.data.from_spark(df1)
+ds1 = from_spark(df1, recover_ray_resources_from_spark=True)
 
 # Ray Dataset to Spark Dataframe
 ds2 = ray.data.from_items([{"id": i} for i in range(1000)])

--- a/python/raydp/tests/test_spark_to_dataset_recover_spark.py
+++ b/python/raydp/tests/test_spark_to_dataset_recover_spark.py
@@ -1,0 +1,29 @@
+import ray
+import raydp
+
+ray.init()
+spark = raydp.init_spark(app_name="RayDP Example",
+                         num_executors=2,
+                         executor_cores=2,
+                         executor_memory="4GB")
+
+
+
+# Spark Dataframe to Ray Dataset
+df1 = spark.range(0, 1000)
+raydp.stop_spark(False)
+ds1 = ray.data.from_spark(df1)
+
+# Ray Dataset to Spark Dataframe
+ds2 = ray.data.from_items([{"id": i} for i in range(1000)])
+df2 = ds2.to_spark(spark)
+
+
+"""
+my run res is:
+after init spark, ray available_resources is:  {'CPU': 2.0, 'memory': 2920706458.0, 'node:127.0.0.1': 1.0, 'object_store_memory': 2147483648.0}
+after convert spark df to ray dataset(use recover_ray_resources_from_spark is True),ray available_resources is:  {'CPU': 3.0, 'object_store_memory': 2147483648.0, 'node:127.0.0.1': 1.0, 'memory': 7215673754.0}
+after call raydp.stop_spark, ray available_resources is:  {'CPU': 4.0, 'memory': 7215673754.0, 'node:127.0.0.1': 1.0, 'object_store_memory': 2147483648.0}
+
+It can be seen that after adding the parameter recover_ray_resources_from_spark, the resources are indeed released
+"""


### PR DESCRIPTION
**Restore the resources occupied by the park, so that the subsequent tasks can use the CPU, memory and other resources used by the previous spark**


When init spark uses a lot of all available resources, if you call ray.data.from_spark(df), the task will be blocked at this time, and ray will give us a warning log to increase resources, as shown in the following figure:
![企业微信截图_16772426688561](https://user-images.githubusercontent.com/46663318/221193411-a4e57850-30ad-4f25-a2fe-96f4cd6476ab.png)

Add a parameter recover_ray_resources_from_spark in ray.data.from_spark. The default value is False, which means that resources are not restored. In this way, users can choose whether to stop sparkSession during the process of converting spark df to ray dataset, so as to release the resources occupied by spark , can convert spark dataframe into ray dataset smoothly, but this will bring another problem, that is, spark and existing dataframe and RDD objects will be unavailable. At this time, you need to call raydp.stop_spark() to stop spark. You also need to use spark, you can re-init_spark
