### PR TITLE
Incorrect Jar path in setup.py

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -42,7 +42,7 @@ TEMP_PATH = "deps"
 CORE_DIR = os.path.abspath("../core")
 BIN_DIR = os.path.abspath("../bin")
 
-JARS_PATH = glob.glob(os.path.join(CORE_DIR, f"**/raydp-*.jar"), recursive=True)
+JARS_PATH = glob.glob(os.path.join(CORE_DIR, f"**/target/raydp-*.jar"), recursive=True)
 JARS_TARGET = os.path.join(TEMP_PATH, "jars")
 
 SCRIPT_PATH = os.path.join(BIN_DIR, f"raydp-submit")


### PR DESCRIPTION
limit direct folder of jars to "target" so that jars from other folders are not included when glob