### PR TITLE
Rename Spark master actor resource config and apply to both actors

### DIFF
--- a/core/raydp-main/src/main/java/org/apache/spark/deploy/RayAppMasterUtils.java
+++ b/core/raydp-main/src/main/java/org/apache/spark/deploy/RayAppMasterUtils.java
@@ -40,7 +40,7 @@ public class RayAppMasterUtils {
     creator.setJvmOptions(jvmOptions);
     for(Map.Entry<String, Double> resource : appMasterResource.entrySet()) {
       String resourceName = resource.getKey()
-              .substring(SparkOnRayConfigs.SPARK_MASTER_ACTOR_RESOURCE_PREFIX.length());
+              .substring(SparkOnRayConfigs.SPARK_MASTER_ACTOR_RESOURCE_PREFIX.length() + 1);
       creator.setResource(resourceName, resource.getValue());
     }
 

--- a/core/raydp-main/src/main/java/org/apache/spark/deploy/RayAppMasterUtils.java
+++ b/core/raydp-main/src/main/java/org/apache/spark/deploy/RayAppMasterUtils.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import io.ray.api.ActorHandle;
 import io.ray.api.Ray;
 import io.ray.api.call.ActorCreator;
+import org.apache.spark.raydp.SparkOnRayConfigs;
 
 public class RayAppMasterUtils {
   public static ActorHandle<RayAppMaster> createAppMaster(
@@ -38,7 +39,9 @@ public class RayAppMasterUtils {
     jvmOptions.add(cp);
     creator.setJvmOptions(jvmOptions);
     for(Map.Entry<String, Double> resource : appMasterResource.entrySet()) {
-      creator.setResource(resource.getKey(), resource.getValue());
+      String resourceName = resource.getKey()
+              .substring(SparkOnRayConfigs.SPARK_MASTER_ACTOR_RESOURCE_PREFIX.length());
+      creator.setResource(resourceName, resource.getValue());
     }
 
     return creator.remote();

--- a/core/raydp-main/src/main/java/org/apache/spark/deploy/RayAppMasterUtils.java
+++ b/core/raydp-main/src/main/java/org/apache/spark/deploy/RayAppMasterUtils.java
@@ -28,7 +28,8 @@ public class RayAppMasterUtils {
   public static ActorHandle<RayAppMaster> createAppMaster(
       String cp,
       String name,
-      List<String> jvmOptions) {
+      List<String> jvmOptions,
+      Map<String, Double> appMasterResource) {
     ActorCreator<RayAppMaster> creator = Ray.actor(RayAppMaster::new, cp);
     if (name != null) {
       creator.setName(name);
@@ -36,6 +37,10 @@ public class RayAppMasterUtils {
     jvmOptions.add("-cp");
     jvmOptions.add(cp);
     creator.setJvmOptions(jvmOptions);
+    for(Map.Entry<String, Double> resource : appMasterResource.entrySet()) {
+      creator.setResource(resource.getKey(), resource.getValue());
+    }
+
     return creator.remote();
   }
 

--- a/core/raydp-main/src/main/java/org/apache/spark/raydp/SparkOnRayConfigs.java
+++ b/core/raydp-main/src/main/java/org/apache/spark/raydp/SparkOnRayConfigs.java
@@ -2,7 +2,8 @@ package org.apache.spark.raydp;
 
 public class SparkOnRayConfigs {
     public static final String RAY_ACTOR_RESOURCE_PREFIX = "spark.ray.actor.resource";
-    public static final String SPARK_MASTER_ACTOR_RESOURCE_PREFIX = "spark.ray.raydp_spark_master.actor.resource";
+    public static final String SPARK_MASTER_ACTOR_RESOURCE_PREFIX =
+            "spark.ray.raydp_spark_master.actor.resource";
     /**
      * CPU cores per Ray Actor which host the Spark executor, the resource is used
      * for scheduling. Default value is 1.

--- a/core/raydp-main/src/main/java/org/apache/spark/raydp/SparkOnRayConfigs.java
+++ b/core/raydp-main/src/main/java/org/apache/spark/raydp/SparkOnRayConfigs.java
@@ -2,6 +2,7 @@ package org.apache.spark.raydp;
 
 public class SparkOnRayConfigs {
     public static final String RAY_ACTOR_RESOURCE_PREFIX = "spark.ray.actor.resource";
+    public static final String SPARK_MASTER_ACTOR_RESOURCE_PREFIX = "spark.ray.raydp_spark_master.actor.resource";
     /**
      * CPU cores per Ray Actor which host the Spark executor, the resource is used
      * for scheduling. Default value is 1.

--- a/core/raydp-main/src/main/scala/org/apache/spark/deploy/raydp/AppMasterJavaBridge.scala
+++ b/core/raydp-main/src/main/scala/org/apache/spark/deploy/raydp/AppMasterJavaBridge.scala
@@ -33,7 +33,7 @@ class AppMasterJavaBridge {
       // init ray, we should set the config by java properties
       Ray.init()
       val name = RayAppMaster.ACTOR_NAME
-      val sparkJvmOptions = sparkProps.asScala.map {
+      val sparkJvmOptions = sparkProps.asScala.toMap.map {
         case (k, v) =>
           "-D" + k + "=" + v
       }.toBuffer

--- a/core/raydp-main/src/main/scala/org/apache/spark/deploy/raydp/AppMasterJavaBridge.scala
+++ b/core/raydp-main/src/main/scala/org/apache/spark/deploy/raydp/AppMasterJavaBridge.scala
@@ -18,13 +18,11 @@
 package org.apache.spark.deploy.raydp
 
 import java.util.{ArrayList, Map}
-
 import scala.collection.JavaConverters._
-
 import io.ray.api.{ActorHandle, Ray}
 import io.ray.runtime.config.RayConfig
-
 import org.apache.spark.deploy.raydp.RayAppMasterUtils
+import org.apache.spark.raydp.SparkOnRayConfigs
 
 class AppMasterJavaBridge {
   private var handle: ActorHandle[RayAppMaster] = null
@@ -38,8 +36,13 @@ class AppMasterJavaBridge {
         case (k, v) =>
           "-D" + k + "=" + v
       }.toBuffer
+
+      val appMasterResources = sparkProps.asScala.filter {
+        case (k, v) => k.startsWith(SparkOnRayConfigs.SPARK_MASTER_ACTOR_RESOURCE_PREFIX)
+      }.map{ case (k, v) => k->double2Double(v.toDouble) }.asJava
+
       handle = RayAppMasterUtils.createAppMaster(
-          extra_cp, name, sparkJvmOptions.asJava)
+          extra_cp, name, sparkJvmOptions.asJava, appMasterResources)
     }
   }
 

--- a/core/raydp-main/src/main/scala/org/apache/spark/deploy/raydp/AppMasterJavaBridge.scala
+++ b/core/raydp-main/src/main/scala/org/apache/spark/deploy/raydp/AppMasterJavaBridge.scala
@@ -18,10 +18,11 @@
 package org.apache.spark.deploy.raydp
 
 import java.util.{ArrayList, Map}
+
 import scala.collection.JavaConverters._
+
 import io.ray.api.{ActorHandle, Ray}
-import io.ray.runtime.config.RayConfig
-import org.apache.spark.deploy.raydp.RayAppMasterUtils
+
 import org.apache.spark.raydp.SparkOnRayConfigs
 
 class AppMasterJavaBridge {

--- a/core/raydp-main/src/main/scala/org/apache/spark/deploy/raydp/AppMasterJavaBridge.scala
+++ b/core/raydp-main/src/main/scala/org/apache/spark/deploy/raydp/AppMasterJavaBridge.scala
@@ -28,7 +28,7 @@ import org.apache.spark.raydp.SparkOnRayConfigs
 class AppMasterJavaBridge {
   private var handle: ActorHandle[RayAppMaster] = null
 
-  def startUpAppMaster(extra_cp: String, sparkProps: Map[String, String]): Unit = {
+  def startUpAppMaster(extra_cp: String, sparkProps: Map[String, Any]): Unit = {
     if (handle == null) {
       // init ray, we should set the config by java properties
       Ray.init()
@@ -40,7 +40,7 @@ class AppMasterJavaBridge {
 
       val appMasterResources = sparkProps.asScala.filter {
         case (k, v) => k.startsWith(SparkOnRayConfigs.SPARK_MASTER_ACTOR_RESOURCE_PREFIX)
-      }.map{ case (k, v) => k->double2Double(v.toDouble) }.asJava
+      }.map{ case (k, v) => k->double2Double(v.toString.toDouble) }.asJava
 
       handle = RayAppMasterUtils.createAppMaster(
           extra_cp, name, sparkJvmOptions.asJava, appMasterResources)

--- a/core/raydp-main/src/main/scala/org/apache/spark/scheduler/cluster/raydp/RayCoarseGrainedSchedulerBackend.scala
+++ b/core/raydp-main/src/main/scala/org/apache/spark/scheduler/cluster/raydp/RayCoarseGrainedSchedulerBackend.scala
@@ -70,7 +70,13 @@ class RayCoarseGrainedSchedulerBackend(
         Ray.init()
         val cp = sys.props("java.class.path")
         val options = RayExternalShuffleService.getShuffleConf(conf)
-        masterHandle = RayAppMasterUtils.createAppMaster(cp, null, options.toBuffer.asJava)
+
+        val appMasterResources = conf.getAll.filter {
+          case (k, v) => k.startsWith(SparkOnRayConfigs.SPARK_MASTER_ACTOR_RESOURCE_PREFIX)
+        }.map{ case (k, v) => k->double2Double(v.toDouble) }
+
+        masterHandle = RayAppMasterUtils.createAppMaster(cp, null, options.toBuffer.asJava,
+          appMasterResources.toMap.asJava)
         uri = new URI(RayAppMasterUtils.getMasterUrl(masterHandle))
       } else {
         uri = new URI(sparkUrl)

--- a/python/raydp/spark/ray_cluster.py
+++ b/python/raydp/spark/ray_cluster.py
@@ -70,11 +70,18 @@ class SparkCluster(Cluster):
 
     def _get_master_resources(self, configs: Dict[str, str]) -> Dict[str, float]:
         resources = {}
-        spark_master_config_prefix = "spark.ray.raydp_spark_master.resource."
-        for key in configs:
-            if key.startswith(spark_master_config_prefix):
-                resource_name = key[len(spark_master_config_prefix):]
-                resources[resource_name] = float(configs[key])
+        deprecated_spark_master_config_prefix = "spark.ray.raydp_spark_master.resource."
+        spark_master_actor_resource_prefix = "spark.ray.raydp_spark_master.actor.resource."
+
+        def get_master_actor_resource(key_prefix: str, resource: Dict[str, float]) -> Dict[str, float]:
+            for key in configs:
+                if key.startswith(key_prefix):
+                    resource_name = key[len(key_prefix):]
+                    resource[resource_name] = float(configs[key])
+            return resource
+
+        resources = get_master_actor_resource(deprecated_spark_master_config_prefix, resources)
+        resources = get_master_actor_resource(spark_master_actor_resource_prefix, resources)
 
         return resources
 

--- a/python/raydp/spark/ray_cluster.py
+++ b/python/raydp/spark/ray_cluster.py
@@ -73,15 +73,18 @@ class SparkCluster(Cluster):
         deprecated_spark_master_config_prefix = "spark.ray.raydp_spark_master.resource."
         spark_master_actor_resource_prefix = "spark.ray.raydp_spark_master.actor.resource."
 
-        def get_master_actor_resource(key_prefix: str, resource: Dict[str, float]) -> Dict[str, float]:
+        def get_master_actor_resource(key_prefix: str,
+                                      resource: Dict[str, float]) -> Dict[str, float]:
             for key in configs:
                 if key.startswith(key_prefix):
                     resource_name = key[len(key_prefix):]
                     resource[resource_name] = float(configs[key])
             return resource
 
-        resources = get_master_actor_resource(deprecated_spark_master_config_prefix, resources)
-        resources = get_master_actor_resource(spark_master_actor_resource_prefix, resources)
+        resources = get_master_actor_resource(deprecated_spark_master_config_prefix,
+                                              resources)
+        resources = get_master_actor_resource(spark_master_actor_resource_prefix,
+                                              resources)
 
         return resources
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -42,7 +42,7 @@ TEMP_PATH = "deps"
 CORE_DIR = os.path.abspath("../core")
 BIN_DIR = os.path.abspath("../bin")
 
-JARS_PATH = glob.glob(os.path.join(CORE_DIR, f"**/raydp-*.jar"), recursive=True)
+JARS_PATH = glob.glob(os.path.join(CORE_DIR, f"**/target/raydp-*.jar"), recursive=True)
 JARS_TARGET = os.path.join(TEMP_PATH, "jars")
 
 SCRIPT_PATH = os.path.join(BIN_DIR, f"raydp-submit")
@@ -90,6 +90,7 @@ class CustomBuildPackageProtos(Command):
 
 try:
     for jar_path in JARS_PATH:
+        print(f"Copying {jar_path} to {JARS_TARGET}")
         copy2(jar_path, JARS_TARGET)
     copy2(SCRIPT_PATH, SCRIPT_TARGET)
 


### PR DESCRIPTION
PR https://github.com/oap-project/raydp/pull/287 only set spark master resource to spark master actor. There is another actor which comprised the driver infra `RayAppMaster` doesn't has the config. It is possible that actor scheduled on worker node and get killed with the worker, causing Spark job stuck with following error:

```
23/03/02 01:55:38 ERROR TransportClient: Failed to send RPC RPC 5816546953779296894 to /10.191.56.127:45851: io.netty.channel.StacklessClosedChannelException
io.netty.channel.StacklessClosedChannelException
	at io.netty.channel.AbstractChannel$AbstractUnsafe.write(Object, ChannelPromise)(Unknown Source)
23/03/02 01:55:38 WARN ExecutorAllocationManager: Unable to reach the cluster manager to request more executors!
```
<img width="1523" alt="Screenshot 2023-03-01 at 5 58 21 PM" src="https://user-images.githubusercontent.com/104795337/222340796-214db894-eea6-421a-a493-7dece6885c47.png">

This PR does the following changes:
* Renames config `spark.ray.raydp_spark_master.resource.*` to `spark.ray.raydp_spark_master.actor.resource.*` to make it a bit less confusing as we have two actors.
* Set the custom resources to both driver actors.
* Fix a bug in the raydp jar package in `setup.py`
* Fix a bug in `startUpAppMaster` where `sparkProps` might be a python dict containing `Dict[str, Any]`
