### PR TITLE
Add a workflow to run ray nightly compatibility test every day

### DIFF
--- a/.github/workflows/ray_nightly_test.yml
+++ b/.github/workflows/ray_nightly_test.yml
@@ -15,13 +15,11 @@
 # limitations under the License.
 #
 
-name: RayDP CI
+name: Ray Nightly0 Compatibility test
 
 on:
-  push:
-    branches: [ main, master ]
-  pull_request:
-    branches: [ main, master ]
+  schedule:
+    - cron: '0 0 * * *'
   workflow_dispatch:
 
 jobs:
@@ -67,6 +65,8 @@ jobs:
           path: ~/Library/Caches/pip
           key: ${{ matrix.os }}-${{ matrix.python-version }}-pip
       - name: Install dependencies
+        env:
+          PYTHON_VERSION: ${{ matrix.python-version }}
         run: |
           python -m pip install --upgrade pip
           pip install wheel
@@ -78,7 +78,18 @@ jobs:
           else
             pip install torch
           fi
-          pip install pyarrow==6.0.1 ray[default]==2.1.0 pytest koalas tensorflow tabulate grpcio-tools wget
+          case $PYTHON_VERSION in
+            3.7)
+              pip install "ray[default] @ https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp37-cp37m-manylinux2014_x86_64.whl"
+              ;;
+            3.8)
+              pip install "ray[default] @ https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp38-cp38-manylinux2014_x86_64.whl"
+              ;;
+            3.9)
+              pip install "ray[default] @ https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp39-cp39-manylinux2014_x86_64.whl"
+              ;;
+          esac
+          pip install pyarrow==6.0.1 pytest koalas tensorflow tabulate grpcio-tools wget
           pip install "xgboost_ray[default]<=0.1.13"
           pip install torchmetrics
           HOROVOD_WITH_GLOO=1

--- a/.github/workflows/raydp.yml
+++ b/.github/workflows/raydp.yml
@@ -29,7 +29,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest ]
+        os: [ ubuntu-latest ]
         python-version: [3.7, 3.8, 3.9]
         spark-version: [3.1.3, 3.2.3, 3.3.2]
 
@@ -67,6 +67,8 @@ jobs:
           path: ~/Library/Caches/pip
           key: ${{ matrix.os }}-${{ matrix.python-version }}-pip
       - name: Install dependencies
+        env:
+          PYTHON_VERSION: ${{ matrix.python-version }}
         run: |
           python -m pip install --upgrade pip
           pip install wheel
@@ -78,7 +80,18 @@ jobs:
           else
             pip install torch
           fi
-          pip install pyarrow==6.0.1 ray[default]==2.1.0 pytest koalas tensorflow tabulate grpcio-tools wget
+          case $PYTHON_VERSION in
+            3.7)
+              pip install "ray[default] @ https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp37-cp37m-manylinux2014_x86_64.whl"
+              ;;
+            3.8)
+              pip install "ray[default] @ https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp38-cp38-manylinux2014_x86_64.whl"
+              ;;
+            3.9)
+              pip install "ray[default] @ https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp39-cp39-manylinux2014_x86_64.whl"
+              ;;
+          esac
+          pip install pyarrow==6.0.1 pytest koalas tensorflow tabulate grpcio-tools wget
           pip install "xgboost_ray[default]<=0.1.13"
           pip install torchmetrics
           HOROVOD_WITH_GLOO=1


### PR DESCRIPTION
Use ray nightly in CI might block us due to bugs introduced from it. Instead, we run this compatibility test every day to see if raydp tests will fail in their CI.