### PR TITLE
[raydp-321] Prepend ":job_id:<jobid>" to java-worker-<jobid>-<pid>.log to avoid too many executor logs flushed to shell console

### DIFF
--- a/core/agent/src/main/java/org/apache/spark/raydp/Agent.java
+++ b/core/agent/src/main/java/org/apache/spark/raydp/Agent.java
@@ -17,9 +17,11 @@
 
 package org.apache.spark.raydp;
 
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.lang.instrument.Instrumentation;
@@ -67,6 +69,13 @@ public class Agent {
       // restore system output/error stream
       System.setErr(DEFAULT_ERR_PS);
       System.setOut(DEFAULT_OUT_PS);
+    }
+    String jobId = System.getenv("RAY_JOB_ID");
+    String rayAddress = System.getProperty("ray.address");
+    if (jobId != null && rayAddress != null) {
+      try (FileWriter writer = new FileWriter(logDir + "/java-worker-" + jobId + "-" + pid + ".log")) {
+        writer.write(":job_id:" + jobId + "\n");
+      }
     }
   }
 }

--- a/core/agent/src/main/java/org/apache/spark/raydp/Agent.java
+++ b/core/agent/src/main/java/org/apache/spark/raydp/Agent.java
@@ -17,7 +17,6 @@
 
 package org.apache.spark.raydp;
 
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;


### PR DESCRIPTION
We still need to prepend job id to log file with ray 2.3 until [#33665](https://github.com/ray-project/ray/pull/33665) is released.