### PR TITLE
Pick up log4j config files from environment variable if not set in config override

### DIFF
--- a/bin/raydp-submit
+++ b/bin/raydp-submit
@@ -53,10 +53,10 @@ while read line; do
   log4j_config+=($line)
 done < <(python3 -c "from raydp import versions; print(versions.SPARK_LOG4J_VERSION); 
 print(versions.SPARK_LOG4J_CONFIG_FILE_NAME_KEY);
-print(versions.SPARK_LOG4J_CONFIG_FILE_NAME_DEFAULT);
+print(os.getenv(\"SPARK_LOG4J_CONFIG_FILE_NAME\", versions.SPARK_LOG4J_CONFIG_FILE_NAME_DEFAULT));
 print(versions.RAY_LOG4J_VERSION);
 print(versions.RAY_LOG4J_CONFIG_FILE_NAME_KEY);
-print(versions.RAY_LOG4J_CONFIG_FILE_NAME_DEFAULT);
+print(os.getenv(\"RAY_LOG4J_CONFIG_FILE_NAME\", versions.RAY_LOG4J_CONFIG_FILE_NAME_DEFAULT));
 ")
 
 

--- a/doc/spark_on_ray.md
+++ b/doc/spark_on_ray.md
@@ -136,5 +136,14 @@ You can use RayDP with Ray autoscaling. When you call `raydp.init_spark`, the au
   For example, you can set Spark's log4j config file to `log4j-cust.properties` and Ray's to `log4j2-cust.xml` like below. Just make sure they are loadable from classpath.
   You can put them in the preferred classpath.
   ```
-  raydp.init_spark(..., configs={'spark.log4j.config.file.name': 'log4j-cust.properties', 'spark.ray.log4j.config.file.name': 'log4j2-cust.xml'})
+  raydp.init_spark(..., configs={'spark.log4j.config.file.name': '<your path...>/log4j-cust.properties', 'spark.ray.log4j.config.file.name': '<your path...>/log4j2-cust.xml'})
+  ```
+  You can also set environment variable `SPARK_LOG4J_CONFIG_FILE_NAME` and `RAY_LOG4J_CONFIG_FILE_NAME` to achieve the same:
+  ```shell
+  export SPARK_LOG4J_CONFIG_FILE_NAME="<your path...>/log4j-cust.properties"
+  export RAY_LOG4J_CONFIG_FILE_NAME="<your path...>/log4j2-cust.xml"
+  ```
+  And you can call `init_spark` without having the override code:
+  ```python
+  raydp.init_spark(..., configs={})
   ```

--- a/doc/spark_on_ray.md
+++ b/doc/spark_on_ray.md
@@ -143,7 +143,7 @@ You can use RayDP with Ray autoscaling. When you call `raydp.init_spark`, the au
   export SPARK_LOG4J_CONFIG_FILE_NAME="<your path...>/log4j-cust.properties"
   export RAY_LOG4J_CONFIG_FILE_NAME="<your path...>/log4j2-cust.xml"
   ```
-  And you can call `init_spark` without having the override code:
+  And you can call `init_spark` without having the override code in Python:
   ```python
   raydp.init_spark(..., configs={})
   ```

--- a/python/raydp/spark/ray_cluster.py
+++ b/python/raydp/spark/ray_cluster.py
@@ -131,11 +131,22 @@ class SparkCluster(Cluster):
         self._configs[SPARK_RAY_LOG4J_FACTORY_CLASS_KEY] = versions.RAY_LOG4J_VERSION
 
         if SPARK_LOG4J_CONFIG_FILE_NAME not in self._configs:
+            # If the config is not passed in by the user, check
+            # by environment variable SPARK_LOG4J_CONFIG_FILE_NAME. This
+            # will give the system admin/infra team a chance to set the
+            # value for all users.
             self._configs[SPARK_LOG4J_CONFIG_FILE_NAME] =\
-                versions.SPARK_LOG4J_CONFIG_FILE_NAME_DEFAULT
+                os.environ.get("SPARK_LOG4J_CONFIG_FILE_NAME",
+                               versions.SPARK_LOG4J_CONFIG_FILE_NAME_DEFAULT)
 
         if RAY_LOG4J_CONFIG_FILE_NAME not in self._configs:
-            self._configs[RAY_LOG4J_CONFIG_FILE_NAME] = versions.RAY_LOG4J_CONFIG_FILE_NAME_DEFAULT
+            # If the config is not passed in by the user, check
+            # by environment variable RAY_LOG4J_CONFIG_FILE_NAME. This
+            # will give the system admin/infra team a chance to set the
+            # value for all users.
+            self._configs[RAY_LOG4J_CONFIG_FILE_NAME] =\
+                os.environ.get("RAY_LOG4J_CONFIG_FILE_NAME",
+                               versions.RAY_LOG4J_CONFIG_FILE_NAME_DEFAULT)
 
         prefer_cp = []
         if SPARK_PREFER_CLASSPATH in self._configs:


### PR DESCRIPTION
Enable system admin or infra team to set log4j config file from `SPARK_LOG4J_CONFIG_FILE_NAME` and `RAY_LOG4J_CONFIG_FILE_NAME` environment variable. So the user don't have to know these system details.