### PR TITLE
[raydp-327] rename ray JVM log file to avoid being monitored and polled

### DIFF
--- a/core/agent/src/main/java/org/apache/spark/raydp/Agent.java
+++ b/core/agent/src/main/java/org/apache/spark/raydp/Agent.java
@@ -69,6 +69,9 @@ public class Agent {
       System.setErr(DEFAULT_ERR_PS);
       System.setOut(DEFAULT_OUT_PS);
     }
+    // below is to write ':job_id:<jobid>' to first line of log file prefixed with 'java-worker' as required by
+    // PR, https://github.com/ray-project/ray/pull/31772.
+    // It's a workaround of the ray 2.3.[0-1] issue going to be fixed by https://github.com/ray-project/ray/pull/33665.
     String jobId = System.getenv("RAY_JOB_ID");
     String rayAddress = System.getProperty("ray.address");
     if (jobId != null && rayAddress != null) {

--- a/core/agent/src/main/java/org/apache/spark/raydp/Agent.java
+++ b/core/agent/src/main/java/org/apache/spark/raydp/Agent.java
@@ -71,8 +71,10 @@ public class Agent {
     }
     String jobId = System.getenv("RAY_JOB_ID");
     String rayAddress = System.getProperty("ray.address");
+    String prefix = System.getProperty("ray.logging.file-prefix", "java-worker");
     if (jobId != null && rayAddress != null) {
-      try (FileWriter writer = new FileWriter(logDir + "/java-worker-" + jobId + "-" + pid + ".log")) {
+      try (FileWriter writer = new FileWriter(logDir + "/" + prefix + "-" +
+          jobId + "-" + pid + ".log")) {
         writer.write(":job_id:" + jobId + "\n");
       }
     }

--- a/core/agent/src/main/java/org/apache/spark/raydp/Agent.java
+++ b/core/agent/src/main/java/org/apache/spark/raydp/Agent.java
@@ -71,11 +71,13 @@ public class Agent {
     }
     String jobId = System.getenv("RAY_JOB_ID");
     String rayAddress = System.getProperty("ray.address");
-    String prefix = System.getProperty("ray.logging.file-prefix", "java-worker");
     if (jobId != null && rayAddress != null) {
-      try (FileWriter writer = new FileWriter(logDir + "/" + prefix + "-" +
-          jobId + "-" + pid + ".log")) {
-        writer.write(":job_id:" + jobId + "\n");
+      String prefix = System.getProperty("ray.logging.file-prefix", "java-worker");
+      if ("java-worker".equals(prefix)) {
+        try (FileWriter writer = new FileWriter(logDir + "/" + prefix + "-" +
+                jobId + "-" + pid + ".log")) {
+          writer.write(":job_id:" + jobId + "\n");
+        }
       }
     }
   }

--- a/core/raydp-main/src/main/java/org/apache/spark/raydp/SparkOnRayConfigs.java
+++ b/core/raydp-main/src/main/java/org/apache/spark/raydp/SparkOnRayConfigs.java
@@ -90,11 +90,14 @@ public class SparkOnRayConfigs {
     public static final String RAY_PREFER_CLASSPATH = "spark.ray.preferClassPath";
 
     /**
-     * The default log file prefix is 'java-worker' which is monitored and polled by ray log monitor.
-     * As spark executor log, we don't want it's monitored and polled since user doesn't care about this relative large
-     * amount of logs in most time.
-     * There is a PR, https://github.com/ray-project/ray/pull/33797, which enables us to change default log file prefix
-     * and thus avoid being monitored and polled. This configure is to change the prefix to 'raydp-java-worker'.
+     * The default log file prefix is 'java-worker' which is monitored and polled
+     * by ray log monitor. As spark executor log, we don't want it's monitored and
+     * polled since user doesn't care about this relative large amount of logs in most time.
+     *
+     * There is a PR, https://github.com/ray-project/ray/pull/33797, which enables
+     * us to change default log file prefix and thus avoid being monitored and polled.
+     *
+     * This configure is to change the prefix to 'raydp-java-worker'.
      */
     public static final String RAYDP_LOGFILE_PREFIX_CFG =
             "-Dray.logging.file-prefix=raydp-java-worker";

--- a/core/raydp-main/src/main/java/org/apache/spark/raydp/SparkOnRayConfigs.java
+++ b/core/raydp-main/src/main/java/org/apache/spark/raydp/SparkOnRayConfigs.java
@@ -88,4 +88,6 @@ public class SparkOnRayConfigs {
      * only.
      */
     public static final String RAY_PREFER_CLASSPATH = "spark.ray.preferClassPath";
+
+    public static final String RAYDP_LOGFILE_PREFIX_CFG = "-Dray.logging.file-prefix=raydp-java-worker";
 }

--- a/core/raydp-main/src/main/java/org/apache/spark/raydp/SparkOnRayConfigs.java
+++ b/core/raydp-main/src/main/java/org/apache/spark/raydp/SparkOnRayConfigs.java
@@ -89,6 +89,13 @@ public class SparkOnRayConfigs {
      */
     public static final String RAY_PREFER_CLASSPATH = "spark.ray.preferClassPath";
 
+    /**
+     * The default log file prefix is 'java-worker' which is monitored and polled by ray log monitor.
+     * As spark executor log, we don't want it's monitored and polled since user doesn't care about this relative large
+     * amount of logs in most time.
+     * There is a PR, https://github.com/ray-project/ray/pull/33797, which enables us to change default log file prefix
+     * and thus avoid being monitored and polled. This configure is to change the prefix to 'raydp-java-worker'.
+     */
     public static final String RAYDP_LOGFILE_PREFIX_CFG =
             "-Dray.logging.file-prefix=raydp-java-worker";
 }

--- a/core/raydp-main/src/main/java/org/apache/spark/raydp/SparkOnRayConfigs.java
+++ b/core/raydp-main/src/main/java/org/apache/spark/raydp/SparkOnRayConfigs.java
@@ -89,5 +89,6 @@ public class SparkOnRayConfigs {
      */
     public static final String RAY_PREFER_CLASSPATH = "spark.ray.preferClassPath";
 
-    public static final String RAYDP_LOGFILE_PREFIX_CFG = "-Dray.logging.file-prefix=raydp-java-worker";
+    public static final String RAYDP_LOGFILE_PREFIX_CFG =
+            "-Dray.logging.file-prefix=raydp-java-worker";
 }

--- a/core/raydp-main/src/main/scala/org/apache/spark/deploy/raydp/AppMasterJavaBridge.scala
+++ b/core/raydp-main/src/main/scala/org/apache/spark/deploy/raydp/AppMasterJavaBridge.scala
@@ -49,7 +49,9 @@ class AppMasterJavaBridge {
       }.map{ case (k, v) => k->double2Double(v.toString.toDouble) }.asJava
 
       handle = RayAppMasterUtils.createAppMaster(
-          extra_cp, name, sparkJvmOptions.asJava, appMasterResources)
+          extra_cp, name,
+          (sparkJvmOptions ++ Seq(SparkOnRayConfigs.RAYDP_LOGFILE_PREFIX_CFG)).asJava,
+          appMasterResources)
     }
   }
 

--- a/core/raydp-main/src/main/scala/org/apache/spark/scheduler/cluster/raydp/RayCoarseGrainedSchedulerBackend.scala
+++ b/core/raydp-main/src/main/scala/org/apache/spark/scheduler/cluster/raydp/RayCoarseGrainedSchedulerBackend.scala
@@ -216,7 +216,7 @@ class RayCoarseGrainedSchedulerBackend(
     val log4jVer = "-D" + SparkOnRayConfigs.LOG4J_FACTORY_CLASS_KEY + "=log4j2"
     val log4jConfigFile = "-D" + SparkOnRayConfigs.RAY_LOG4J_CONFIG_FILE_NAME + "=" +
       conf.get(SparkOnRayConfigs.RAY_LOG4J_CONFIG_FILE_NAME_KEY)
-    Seq(agent, log4jVer, log4jConfigFile)
+    Seq(agent, log4jVer, log4jConfigFile, SparkOnRayConfigs.RAYDP_LOGFILE_PREFIX_CFG)
   }
 
   def waitForRegistration(): Unit = {


### PR DESCRIPTION
As stated in https://github.com/ray-project/ray/pull/33797, it's not necessary for ray monitoring ray JVM logs.

This ticket is to make corresponding changes in raydp by setting JVM log file prefix to 'raydp-java-worker'.
The ray PR will be merged and released later. But this ticket can work with and without the PR.

Note: PR https://github.com/ray-project/ray/pull/33797 and this PR don't change any existing raydp behavior in terms of logs printed in spark-shell console. 

The JVM log file here refers to programmatically generated spark executor log file which is different than STDOUT and STDERR point to raylet.out and raylet.err respectively. When you log something, like 'log.info("Finished task....")', in executor, it prints to the JVM log file. But when you log without log4j , like 'print("xxxx")', it prints to STDOUT, that is raylet.out which will be in turn sent to user's console.