### PR TITLE
[raydp-332] Fix security issue of protobuf < 3.19.5

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -102,7 +102,7 @@ try:
         "ray >= 2.1.0",
         "pyspark >= 3.1.1, <= 3.3.2",
         "netifaces",
-        "protobuf >= 3.15.3, <= 3.20.3, != 3.19.5"
+        "protobuf > 3.19.5, <= 3.20.3"
     ]
 
     _packages = find_packages()


### PR DESCRIPTION
There is a security issue report, https://github.com/oap-project/raydp/security/dependabot/6.

```
Package protobuf

Affected versions >= 3.19.0, < 3.19.5

Patched version 3.19.5

 protobuf-cpp and protobuf-python have potential Denial of Service issue
```

To fix it, we limit protobuf > 3.19.5 and <= 3.20.3