### PR TITLE
[raydp-334] fix the workaround of working with ray 2.3.[0-1]

### DIFF
--- a/core/agent/src/main/java/org/apache/spark/raydp/Agent.java
+++ b/core/agent/src/main/java/org/apache/spark/raydp/Agent.java
@@ -75,13 +75,15 @@ public class Agent {
     String jobId = System.getenv("RAY_JOB_ID");
     String rayAddress = System.getProperty("ray.address");
     if (jobId != null && rayAddress != null) {
-      String prefix = System.getProperty("ray.logging.file-prefix", "java-worker");
-      if ("java-worker".equals(prefix)) {
-        try (FileWriter writer = new FileWriter(logDir + "/" + prefix + "-" +
-                jobId + "-" + pid + ".log")) {
-          writer.write(":job_id:" + jobId + "\n");
-        }
+      String prefix = "java-worker";
+      // TODO: uncomment after the ray PR #33665 released
+      // String prefix = System.getProperty("ray.logging.file-prefix", "java-worker");
+      // if ("java-worker".equals(prefix)) {
+      try (FileWriter writer = new FileWriter(logDir + "/" + prefix + "-" +
+              jobId + "-" + pid + ".log")) {
+        writer.write(":job_id:" + jobId + "\n");
       }
+      // }
     }
   }
 }


### PR DESCRIPTION
we need to prepend jobid to hardcoded prefix log file, java-worker-*.log instead of getting prefix from the "ray.logging.file-prefix" system property since ray hasn't applied the fix (https://github.com/ray-project/ray/pull/33665) yet.