### PR TITLE
Fix maven dependency and prepare for release

### DIFF
--- a/core/agent/pom.xml
+++ b/core/agent/pom.xml
@@ -43,14 +43,19 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>1.7.25</version>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.17.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <version>2.17.1</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-            <version>1.7.25</version>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.32</version>
         </dependency>
         <dependency>
             <groupId>com.intel</groupId>

--- a/core/agent/src/main/java/org/apache/spark/raydp/Agent.java
+++ b/core/agent/src/main/java/org/apache/spark/raydp/Agent.java
@@ -17,7 +17,7 @@
 
 package org.apache.spark.raydp;
 
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
 
 import java.io.File;
 import java.io.FileWriter;
@@ -59,7 +59,7 @@ public class Agent {
       System.setOut(ps);
       System.setErr(ps);
       // slf4j binding
-      LoggerFactory.getLogger(Agent.class);
+      LogManager.getLogger(Agent.class);
     } catch (Exception e) {
       e.printStackTrace();
     } finally {

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -13,10 +13,16 @@
   <url>https://github.com/oap-project/raydp.git</url>
 
   <properties>
-    <spark.version>3.2.1</spark.version>
-    <spark321.version>3.2.1</spark321.version>
+    <spark.version>3.4.0</spark.version>
+    <spark322.version>3.2.2</spark322.version>
     <spark330.version>3.3.0</spark330.version>
     <spark340.version>3.4.0</spark340.version>
+    <snappy.version>1.1.10.1</snappy.version>
+    <netty.version>4.1.94.Final</netty.version>
+    <commons.text.version>1.10.0</commons.text.version>
+    <commons.compress.version>1.21</commons.compress.version>
+    <protobuf.version>3.16.3</protobuf.version>
+    <ivy.version>2.5.1</ivy.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
@@ -38,9 +44,20 @@
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-core_${scala.binary.version}</artifactId>
       <version>${spark.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.xerial.snappy</groupId>
+          <artifactId>snappy-java</artifactId>
+        </exclusion>
+      </exclusions>
       <scope>provided</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.xerial.snappy</groupId>
+      <artifactId>snappy-java</artifactId>
+      <version>${snappy.version}</version>
+    </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-sql_${scala.binary.version}</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -13,7 +13,7 @@
   <url>https://github.com/oap-project/raydp.git</url>
 
   <properties>
-    <spark.version>3.4.0</spark.version>
+    <spark.version>3.2.2</spark.version>
     <spark322.version>3.2.2</spark322.version>
     <spark330.version>3.3.0</spark330.version>
     <spark340.version>3.4.0</spark340.version>

--- a/core/shims/pom.xml
+++ b/core/shims/pom.xml
@@ -17,7 +17,7 @@
 
   <modules>
     <module>common</module>
-    <module>spark321</module>
+    <module>spark322</module>
     <module>spark330</module>
     <module>spark340</module>
   </modules>

--- a/core/shims/spark321/src/main/resources/META-INF/services/com.intel.raydp.shims.SparkShimProvider
+++ b/core/shims/spark321/src/main/resources/META-INF/services/com.intel.raydp.shims.SparkShimProvider
@@ -1,1 +1,0 @@
-com.intel.raydp.shims.spark321.SparkShimProvider

--- a/core/shims/spark322/pom.xml
+++ b/core/shims/spark322/pom.xml
@@ -11,8 +11,8 @@
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <artifactId>raydp-shims-spark321</artifactId>
-  <name>RayDP Shims for Spark 3.2.1</name>
+  <artifactId>raydp-shims-spark322</artifactId>
+  <name>RayDP Shims for Spark 3.2.2</name>
   <packaging>jar</packaging>
 
   <properties>
@@ -66,14 +66,53 @@
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-sql_${scala.binary.version}</artifactId>
-      <version>${spark321.version}</version>
+      <version>${spark322.version}</version>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.protobuf</groupId>
+          <artifactId>protobuf-java</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-core_${scala.binary.version}</artifactId>
-      <version>${spark321.version}</version>
+      <version>${spark322.version}</version>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.xerial.snappy</groupId>
+          <artifactId>snappy-java</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.commons</groupId>
+          <artifactId>commons-compress</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.ivy</groupId>
+          <artifactId>ivy</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
-  </dependencies>
+    <dependency>
+      <groupId>org.xerial.snappy</groupId>
+      <artifactId>snappy-java</artifactId>
+      <version>${snappy.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-compress</artifactId>
+      <version>${commons.compress.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ivy</groupId>
+      <artifactId>ivy</artifactId>
+      <version>${ivy.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <version>${protobuf.version}</version>
+    </dependency>
 </project>

--- a/core/shims/spark322/pom.xml
+++ b/core/shims/spark322/pom.xml
@@ -115,4 +115,5 @@
       <artifactId>protobuf-java</artifactId>
       <version>${protobuf.version}</version>
     </dependency>
+  </dependencies>
 </project>

--- a/core/shims/spark322/src/main/resources/META-INF/services/com.intel.raydp.shims.SparkShimProvider
+++ b/core/shims/spark322/src/main/resources/META-INF/services/com.intel.raydp.shims.SparkShimProvider
@@ -1,0 +1,1 @@
+com.intel.raydp.shims.spark322.SparkShimProvider

--- a/core/shims/spark322/src/main/scala/com/intel/raydp/shims/SparkShimProvider.scala
+++ b/core/shims/spark322/src/main/scala/com/intel/raydp/shims/SparkShimProvider.scala
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package com.intel.raydp.shims.spark321
+package com.intel.raydp.shims.spark322
 
 import com.intel.raydp.shims.{SparkShims, SparkShimDescriptor}
 
@@ -37,7 +37,7 @@ object SparkShimProvider {
 
 class SparkShimProvider extends com.intel.raydp.shims.SparkShimProvider {
   def createShim: SparkShims = {
-    new Spark321Shims()
+    new Spark322Shims()
   }
 
   def matches(version: String): Boolean = {

--- a/core/shims/spark322/src/main/scala/com/intel/raydp/shims/SparkShims.scala
+++ b/core/shims/spark322/src/main/scala/com/intel/raydp/shims/SparkShims.scala
@@ -15,19 +15,19 @@
  * limitations under the License.
  */
 
-package com.intel.raydp.shims.spark321
+package com.intel.raydp.shims.spark322
 
 import org.apache.spark.{SparkEnv, TaskContext}
 import org.apache.spark.api.java.JavaRDD
 import org.apache.spark.executor.RayDPExecutorBackendFactory
-import org.apache.spark.executor.spark321._
-import org.apache.spark.spark321.TaskContextUtils
+import org.apache.spark.executor.spark322._
+import org.apache.spark.spark322.TaskContextUtils
 import org.apache.spark.sql.{DataFrame, SparkSession}
-import org.apache.spark.sql.spark321.SparkSqlUtils
+import org.apache.spark.sql.spark322.SparkSqlUtils
 
 import com.intel.raydp.shims.{ShimDescriptor, SparkShims}
 
-class Spark321Shims extends SparkShims {
+class Spark322Shims extends SparkShims {
   override def getShimDescriptor: ShimDescriptor = SparkShimProvider.DESCRIPTOR
 
   override def toDataFrame(
@@ -38,7 +38,7 @@ class Spark321Shims extends SparkShims {
   }
 
   override def getExecutorBackendFactory(): RayDPExecutorBackendFactory = {
-    new RayDPSpark321ExecutorBackendFactory()
+    new RayDPSpark322ExecutorBackendFactory()
   }
 
   override def getDummyTaskContext(partitionId: Int, env: SparkEnv): TaskContext = {

--- a/core/shims/spark322/src/main/scala/org/apache/spark/TaskContextUtils.scala
+++ b/core/shims/spark322/src/main/scala/org/apache/spark/TaskContextUtils.scala
@@ -15,14 +15,16 @@
  * limitations under the License.
  */
 
-package org.apache.spark.sql.spark321
+package org.apache.spark.spark322
 
-import org.apache.spark.api.java.JavaRDD
-import org.apache.spark.sql.{DataFrame, SparkSession, SQLContext}
-import org.apache.spark.sql.execution.arrow.ArrowConverters
+import java.util.Properties
 
-object SparkSqlUtils {
-  def toDataFrame(rdd: JavaRDD[Array[Byte]], schema: String, session: SparkSession): DataFrame = {
-    ArrowConverters.toDataFrame(rdd, schema, new SQLContext(session))
+import org.apache.spark.{SparkEnv, TaskContext, TaskContextImpl}
+import org.apache.spark.memory.TaskMemoryManager
+
+object TaskContextUtils {
+  def getDummyTaskContext(partitionId: Int, env: SparkEnv): TaskContext = {
+    new TaskContextImpl(0, 0, partitionId, -1024, 0,
+        new TaskMemoryManager(env.memoryManager, 0), new Properties(), env.metricsSystem)
   }
 }

--- a/core/shims/spark322/src/main/scala/org/apache/spark/executor/RayDPSpark322ExecutorBackendFactory.scala
+++ b/core/shims/spark322/src/main/scala/org/apache/spark/executor/RayDPSpark322ExecutorBackendFactory.scala
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.spark.executor.spark321
+package org.apache.spark.executor.spark322
 
 import java.net.URL
 
@@ -25,7 +25,7 @@ import org.apache.spark.executor.RayDPExecutorBackendFactory
 import org.apache.spark.resource.ResourceProfile
 import org.apache.spark.rpc.RpcEnv
 
-class RayDPSpark321ExecutorBackendFactory
+class RayDPSpark322ExecutorBackendFactory
     extends RayDPExecutorBackendFactory {
   override def createExecutorBackend(
       rpcEnv: RpcEnv,

--- a/core/shims/spark322/src/main/scala/org/apache/spark/sql/SparkSqlUtils.scala
+++ b/core/shims/spark322/src/main/scala/org/apache/spark/sql/SparkSqlUtils.scala
@@ -15,16 +15,14 @@
  * limitations under the License.
  */
 
-package org.apache.spark.spark321
+package org.apache.spark.sql.spark322
 
-import java.util.Properties
+import org.apache.spark.api.java.JavaRDD
+import org.apache.spark.sql.{DataFrame, SparkSession, SQLContext}
+import org.apache.spark.sql.execution.arrow.ArrowConverters
 
-import org.apache.spark.{SparkEnv, TaskContext, TaskContextImpl}
-import org.apache.spark.memory.TaskMemoryManager
-
-object TaskContextUtils {
-  def getDummyTaskContext(partitionId: Int, env: SparkEnv): TaskContext = {
-    new TaskContextImpl(0, 0, partitionId, -1024, 0,
-        new TaskMemoryManager(env.memoryManager, 0), new Properties(), env.metricsSystem)
+object SparkSqlUtils {
+  def toDataFrame(rdd: JavaRDD[Array[Byte]], schema: String, session: SparkSession): DataFrame = {
+    ArrowConverters.toDataFrame(rdd, schema, new SQLContext(session))
   }
 }

--- a/core/shims/spark330/pom.xml
+++ b/core/shims/spark330/pom.xml
@@ -68,12 +68,61 @@
       <artifactId>spark-sql_${scala.binary.version}</artifactId>
       <version>${spark330.version}</version>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.protobuf</groupId>
+          <artifactId>protobuf-java</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-core_${scala.binary.version}</artifactId>
       <version>${spark330.version}</version>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.xerial.snappy</groupId>
+          <artifactId>snappy-java</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-handler</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.commons</groupId>
+          <artifactId>commons-text</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.ivy</groupId>
+          <artifactId>ivy</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.xerial.snappy</groupId>
+      <artifactId>snappy-java</artifactId>
+      <version>${snappy.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-handler</artifactId>
+      <version>${netty.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-text</artifactId>
+      <version>${commons.text.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ivy</groupId>
+      <artifactId>ivy</artifactId>
+      <version>${ivy.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <version>${protobuf.version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/core/shims/spark340/pom.xml
+++ b/core/shims/spark340/pom.xml
@@ -74,6 +74,26 @@
       <artifactId>spark-core_${scala.binary.version}</artifactId>
       <version>${spark340.version}</version>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.xerial.snappy</groupId>
+          <artifactId>snappy-java</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-handler</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.xerial.snappy</groupId>
+      <artifactId>snappy-java</artifactId>
+      <version>${snappy.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-handler</artifactId>
+      <version>${netty.version}</version>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
1. [core] Upgrade Spark from 3.2.1 to 3.4.0
2. Replace all log4j 1.x dependencies by log4j2
3. Upgrade Spark shims 3.2.1 to 3.2.2
4. Fix all critical and high issues reported by Snyk.