### PR TITLE
Implement Spark executor node affinity using custom resource

### DIFF
--- a/.github/workflows/raydp.yml
+++ b/.github/workflows/raydp.yml
@@ -105,8 +105,7 @@ jobs:
       - name: Test with pytest
         run: |
           ray start --head --num-cpus 6
-          pytest python/raydp/tests/ -v -m"not error_on_custom_resource"
-          pytest python/raydp/tests/ -v -m"error_on_custom_resource"
+          pytest python/raydp/tests/ -v
           ray stop --force
       - name: Test Examples
         run: |

--- a/core/raydp-main/src/main/java/org/apache/spark/raydp/SparkOnRayConfigs.java
+++ b/core/raydp-main/src/main/java/org/apache/spark/raydp/SparkOnRayConfigs.java
@@ -1,7 +1,12 @@
 package org.apache.spark.raydp;
 
+import scala.deprecated;
+
 public class SparkOnRayConfigs {
+    @Deprecated
     public static final String RAY_ACTOR_RESOURCE_PREFIX = "spark.ray.actor.resource";
+
+    public static final String SPARK_EXECUTOR_ACTOR_RESOURCE_PREFIX = "spark.ray.raydp_spark_executor.actor.resource";
     public static final String SPARK_MASTER_ACTOR_RESOURCE_PREFIX =
             "spark.ray.raydp_spark_master.actor.resource";
     /**
@@ -10,7 +15,16 @@ public class SparkOnRayConfigs {
      * This is different from spark.executor.cores, which defines the task parallelism
      * inside a stage.
      */
+    @Deprecated
     public static final String RAY_ACTOR_CPU_RESOURCE = RAY_ACTOR_RESOURCE_PREFIX + ".cpu";
+
+    /**
+     * CPU cores per Ray Actor which host the Spark executor, the resource is used
+     * for scheduling. Default value is 1.
+     * This is different from spark.executor.cores, which defines the task parallelism
+     * inside a stage.
+     */
+    public static final String SPARK_EXECUTOR_ACTOR_CPU_RESOURCE = SPARK_EXECUTOR_ACTOR_RESOURCE_PREFIX + ".cpu";
 
     public static final int DEFAULT_SPARK_CORES_PER_EXECUTOR = 1;
 

--- a/core/raydp-main/src/main/java/org/apache/spark/raydp/SparkOnRayConfigs.java
+++ b/core/raydp-main/src/main/java/org/apache/spark/raydp/SparkOnRayConfigs.java
@@ -1,12 +1,12 @@
 package org.apache.spark.raydp;
 
-import scala.deprecated;
 
 public class SparkOnRayConfigs {
     @Deprecated
     public static final String RAY_ACTOR_RESOURCE_PREFIX = "spark.ray.actor.resource";
 
-    public static final String SPARK_EXECUTOR_ACTOR_RESOURCE_PREFIX = "spark.ray.raydp_spark_executor.actor.resource";
+    public static final String SPARK_EXECUTOR_ACTOR_RESOURCE_PREFIX =
+            "spark.ray.raydp_spark_executor.actor.resource";
     public static final String SPARK_MASTER_ACTOR_RESOURCE_PREFIX =
             "spark.ray.raydp_spark_master.actor.resource";
     /**
@@ -24,7 +24,8 @@ public class SparkOnRayConfigs {
      * This is different from spark.executor.cores, which defines the task parallelism
      * inside a stage.
      */
-    public static final String SPARK_EXECUTOR_ACTOR_CPU_RESOURCE = SPARK_EXECUTOR_ACTOR_RESOURCE_PREFIX + ".cpu";
+    public static final String SPARK_EXECUTOR_ACTOR_CPU_RESOURCE =
+            SPARK_EXECUTOR_ACTOR_RESOURCE_PREFIX + ".cpu";
 
     public static final int DEFAULT_SPARK_CORES_PER_EXECUTOR = 1;
 

--- a/core/raydp-main/src/main/scala/org/apache/spark/deploy/raydp/RayAppMaster.scala
+++ b/core/raydp-main/src/main/scala/org/apache/spark/deploy/raydp/RayAppMaster.scala
@@ -260,7 +260,9 @@ class RayAppMaster(host: String,
       val executorId = s"${appInfo.getNextExecutorId()}"
 
       logInfo(s"Requesting Spark executor with Ray logical resource " +
-        s"{ CPU: ${rayActorCPU} }..")
+        s"{ CPU: ${rayActorCPU}, " +
+        s"${appInfo.desc.resourceReqsPerExecutor
+          .map{ case (name, amount) => s"${name}: ${amount}"}.mkString(", ")} }..")
       // TODO: Support generic fractional logical resources using prefix spark.ray.actor.resource.*
 
       val handler = RayExecutorUtils.createExecutorActor(
@@ -269,7 +271,8 @@ class RayAppMaster(host: String,
         memory,
         // This won't work, Spark expect integer in custom resources,
         // please see python test test_spark_on_fractional_custom_resource
-        appInfo.desc.resourceReqsPerExecutor.map(pair => (pair._1, Double.box(pair._2))).asJava,
+        appInfo.desc.resourceReqsPerExecutor
+          .map{ case (name, amount) => (name, Double.box(amount))}.asJava,
         placementGroup,
         getNextBundleIndex,
         seqAsJavaList(appInfo.desc.command.javaOpts))

--- a/core/raydp-main/src/main/scala/org/apache/spark/scheduler/cluster/raydp/RayCoarseGrainedSchedulerBackend.scala
+++ b/core/raydp-main/src/main/scala/org/apache/spark/scheduler/cluster/raydp/RayCoarseGrainedSchedulerBackend.scala
@@ -174,8 +174,9 @@ class RayCoarseGrainedSchedulerBackend(
     val numExecutors = conf.get(config.EXECUTOR_INSTANCES).get
     val sparkCoresPerExecutor = coresPerExecutor
       .getOrElse(SparkOnRayConfigs.DEFAULT_SPARK_CORES_PER_EXECUTOR)
-    val rayActorCPU = conf.get(SparkOnRayConfigs.RAY_ACTOR_CPU_RESOURCE,
-      sparkCoresPerExecutor.toString).toDouble
+    val rayActorCPU = conf.get(SparkOnRayConfigs.SPARK_EXECUTOR_ACTOR_CPU_RESOURCE,
+      conf.get(SparkOnRayConfigs.RAY_ACTOR_CPU_RESOURCE,
+        sparkCoresPerExecutor.toString)).toDouble
 
     val appDesc = ApplicationDescription(name = sc.appName, numExecutors = numExecutors,
       coresPerExecutor = coresPerExecutor, memoryPerExecutorMB = sc.executorMemory,
@@ -201,13 +202,13 @@ class RayCoarseGrainedSchedulerBackend(
 
   def parseRayDPResourceRequirements(sparkConf: SparkConf): Map[String, Double] = {
     sparkConf.getAllWithPrefix(
-      s"${SparkOnRayConfigs.RAY_ACTOR_RESOURCE_PREFIX}.")
+      s"${SparkOnRayConfigs.SPARK_EXECUTOR_ACTOR_CPU_RESOURCE}.")
       .filter{ case (key, _) => key.toLowerCase() != "cpu" }
       .map{ case (key, _) => key }
       .distinct
       .map(name => {
         val amountDouble = sparkConf.get(
-          s"${SparkOnRayConfigs.RAY_ACTOR_RESOURCE_PREFIX}.${name}",
+          s"${SparkOnRayConfigs.SPARK_EXECUTOR_ACTOR_CPU_RESOURCE}.${name}",
           0d.toString).toDouble
         name->amountDouble
       })

--- a/doc/spark_on_ray.md
+++ b/doc/spark_on_ray.md
@@ -32,7 +32,7 @@ available_node_types:
 ### Spark executor actors node affinity
 
 Similar to master actors node affinity, you can also schedule Spark executor to a specific set of nodes
-using custom resource:
+using custom resource, using configuration `spark.ray.raydp_spark_executor.actor.resource.[RESOURCE_NAME]`:
 
 ```python
 import raydp
@@ -51,7 +51,7 @@ And here is the cluster YAML with the customer resource:
 available_node_types:
   spark_on_spot:  # Spark only nodes
     resources:
-      spark_executor: 100 # custom resource indicates these node group is for Spark only
+      spark_executor: 100 # custom resource, with name matches the one set in spark.ray.raydp_spark_executor.actor.resource.*
     min_workers: 2
     max_workers: 10  # changing this also need to change the global max_workers
     node_config:
@@ -76,7 +76,7 @@ spark = raydp.init_spark(app_name='RayDP Oversubscribe Example',
                          executor_memory=1 * 1024 * 1024 * 1024,
                          configs = {
                              # ...
-                             'spark.ray.raydp_spark_executor.actor.resource.spark_executor': 1,  # The actor only occupy 1 logical CPU slots from Ray
+                             'spark.ray.raydp_spark_executor.actor.resource.cpu': 1,  # The actor only occupy 1 logical CPU slots from Ray
                          })
 ```
 

--- a/python/raydp/tests/conftest.py
+++ b/python/raydp/tests/conftest.py
@@ -78,7 +78,7 @@ def spark_on_ray_small(request):
 def spark_on_ray_2_executors(request):
     ray.shutdown()
     if request.param == "local":
-        ray.init(address="local", num_cpus=10, include_dashboard=False)
+        ray.init(address="local", num_cpus=6, include_dashboard=False)
     else:
         ray.init(address=request.param)
     node_ip = ray.util.get_node_ip_address()

--- a/python/raydp/tests/test_spark_cluster.py
+++ b/python/raydp/tests/test_spark_cluster.py
@@ -59,6 +59,15 @@ def test_spark_on_fractional_custom_resource(spark_on_ray_fraction_custom_resour
     assert False
 
 
+def test_spark_executor_node_affinity(spark_on_ray_executor_node_affinity):
+    print(raydp.__file__)
+    spark = raydp.init_spark(app_name="test_executor_node_affinity",
+                             num_executors=1, executor_cores=3, executor_memory="500M",
+                             configs={"spark.ray.actor.resource.spark_executor": "1"})
+    result = spark.range(0, 10).count()
+    assert result == 10
+
+
 def test_spark_remote(ray_cluster):
     @ray.remote
     class SparkRemote:
@@ -171,6 +180,7 @@ def test_placement_group(ray_cluster):
     ])
     assert num_non_removed_pgs == 0
 
+
 def test_reconstruction():
     cluster = ray.cluster_utils.Cluster()
     # Head node has 2 cores for necessray actors
@@ -183,8 +193,8 @@ def test_reconstruction():
     # init_spark before adding nodes to ensure drivers connect to the head node
     spark = raydp.init_spark('a', 2, 1, '500m', fault_tolerant_mode=True)
     # Add two nodes, 1 executor each
-    node_to_kill = cluster.add_node(num_cpus=1, include_dashboard=False,object_store_memory=10**8)
-    second_node = cluster.add_node(num_cpus=1, include_dashboard=False,object_store_memory=10**8)
+    node_to_kill = cluster.add_node(num_cpus=1, include_dashboard=False, object_store_memory=10 ** 8)
+    second_node = cluster.add_node(num_cpus=1, include_dashboard=False, object_store_memory=10 ** 8)
     # wait for executors to start
     time.sleep(5)
     # df should be large enough so that result will be put into plasma
@@ -202,6 +212,7 @@ def test_reconstruction():
     raydp.stop_spark()
     ray.shutdown()
     cluster.shutdown()
+
 
 @pytest.mark.skip("flaky")
 def test_custom_installed_spark(custom_spark_dir):
@@ -225,6 +236,7 @@ def test_custom_installed_spark(custom_spark_dir):
     assert result == 10
     assert spark_home == custom_spark_dir
 
+
 def start_spark(barrier, i, results):
     try:
         # connect to the cluster started before pytest
@@ -239,6 +251,7 @@ def start_spark(barrier, i, results):
         ray.shutdown()
     except Exception as e:
         results[i] = -1
+
 
 def test_init_spark_twice():
     num_processes = 2
@@ -255,6 +268,7 @@ def test_init_spark_twice():
 
     assert results[0] == 10
     assert results[1] == 10
+
 
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", __file__]))

--- a/python/raydp/tests/test_spark_cluster.py
+++ b/python/raydp/tests/test_spark_cluster.py
@@ -39,33 +39,67 @@ def test_spark(spark_on_ray_small):
     assert result == 10
 
 
-def test_spark_on_fractional_cpu(spark_on_ray_fractional_cpu):
-    spark = spark_on_ray_fractional_cpu
-    result = spark.range(0, 10).count()
-    assert result == 10
+def test_legacy_spark_on_fractional_cpu():
+    cluster = Cluster(
+        initialize_head=True,
+        connect=True,
+        head_node_args={
+            "num_cpus": 2
+        })
 
-
-@pytest.mark.error_on_custom_resource
-def test_spark_on_fractional_custom_resource(spark_on_ray_fraction_custom_resource):
-    try:
-        spark = raydp.init_spark(app_name="test_custom_resource_fraction",
-                                 num_executors=1, executor_cores=3, executor_memory="500M",
-                                 configs={"spark.executor.resource.CUSTOM.amount": "0.1"})
-        spark.range(0, 10).count()
-    except Exception:
-        assert True
-        return
-
-    assert False
-
-
-def test_spark_executor_node_affinity(spark_on_ray_executor_node_affinity):
-    print(raydp.__file__)
-    spark = raydp.init_spark(app_name="test_executor_node_affinity",
+    spark = raydp.init_spark(app_name="test_cpu_fraction",
                              num_executors=1, executor_cores=3, executor_memory="500M",
-                             configs={"spark.ray.actor.resource.spark_executor": "1"})
+                             configs={"spark.ray.actor.resource.cpu": "0.1"})
     result = spark.range(0, 10).count()
     assert result == 10
+
+    spark.stop()
+    raydp.stop_spark()
+    time.sleep(5)
+    ray.shutdown()
+    cluster.shutdown()
+
+
+def test_spark_on_fractional_cpu():
+    cluster = Cluster(
+        initialize_head=True,
+        connect=True,
+        head_node_args={
+            "num_cpus": 2
+        })
+
+    spark = raydp.init_spark(app_name="test_cpu_fraction",
+                             num_executors=1, executor_cores=3, executor_memory="500M",
+                             configs={"spark.ray.raydp_spark_executor.actor.resource.cpu": "0.1"})
+    result = spark.range(0, 10).count()
+    assert result == 10
+
+    spark.stop()
+    raydp.stop_spark()
+    time.sleep(5)
+    ray.shutdown()
+    cluster.shutdown()
+
+
+def test_spark_executor_node_affinity():
+    cluster = Cluster(
+        initialize_head=True,
+        connect=True,
+        head_node_args={
+            "num_cpus": 1,
+        })
+    cluster.add_node(num_cpus=2, resources={"spark_executor": 10})
+
+    spark = raydp.init_spark(app_name="test_executor_node_affinity",
+                             num_executors=1, executor_cores=2, executor_memory="500M",
+                             configs={"spark.ray.raydp_spark_executor.actor.resource.spark_executor": "1"})
+    result = spark.range(0, 10).count()
+    assert result == 10
+
+    raydp.stop_spark()
+    time.sleep(5)
+    ray.shutdown()
+    cluster.shutdown()
 
 
 def test_spark_remote(ray_cluster):
@@ -83,6 +117,7 @@ def test_spark_remote(ray_cluster):
         def stop(self):
             self.spark.stop()
             raydp.stop_spark()
+            time.sleep(5)
 
     driver = SparkRemote.remote()
     result = ray.get(driver.run.remote())


### PR DESCRIPTION
# What Problem Does the PR Solve
This PR enable `raydp` pin Spark executors on a specific set of machines in a Ray cluster -- a feature we found useful in our production. It is useful when the Ray cluster contains heterogeneous workloads (i.e. workloads using both Spark and Native Ray) and the total resource is less than the max resource Spark could potentially request -- which is possible in following cases:
- User specify large number of Spark executors, which is more than the total amount of CPU in the cluster. In this case it could cause other Ray workload starving because Spark occupied all resources.
- Dynamic allocation requests more actors than total CPU -- this is possible when dynamic allocation starts

In both scenarios, we want to limit the scheduling of the Spark executor actors into a subset of machines to avoid the Spark job take all resources in the ray cluster and starve other Ray workloads.
Another scenario this feature is useful is the Spark cluster needs to be schedule on special nodes i.e. spot vs. on demand.

This feature could also benefit multi-tenant Ray clusters where different users want to run their job on different nodegroups.
With the new feature, we can define a set of machines that only for scheduling Spark executors in the Ray cluster, for example:

```yaml
# Ray cluster config
  # ....
  spark_on_spot:  # Spark only nodes
    resources:
      spark_executor: 100 # custom resource indicates these node group is for Spark only
    min_workers: 2
    max_workers: 10  # changing this also need to change the global max_workers
    node_config:
      # ....
  general_spot:  # Nodes for general Ray workloads
    min_workers: 2
    max_workers: 10  # changing this also need to change the global max_workers
    node_config:
      # ...
``` 

Then when initialize Spark session:
```python
spark = raydp.init_spark(app_name='RayDP Example',
                         num_executors=executor_count,
                         executor_cores=3,
                         executor_memory=1 * 1024 * 1024 * 1024,
                         configs = {
                             ...
                             'spark.ray.raydp_spark_executor.actor.resource.spark_executor': 1,  # Schedule executor on nodes with custom resource spark_executor
                         })
```