### PR TITLE
Fix Jackson and Scala vulnerabilities

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -29,7 +29,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <scala.version>2.12.15</scala.version>
-    <jackson.version>2.13.4</jackson.version>
+    <jackson.version>2.13.5</jackson.version>
     <scala.binary.version>2.12</scala.binary.version>
   </properties>
 
@@ -153,7 +153,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>2.13.4.2</version>
+        <version>${jackson.version}</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>

--- a/core/raydp-main/pom.xml
+++ b/core/raydp-main/pom.xml
@@ -240,15 +240,12 @@
         <artifactId>maven-assembly-plugin</artifactId>
         <version>3.0.0</version>
         <configuration>
-          <!--<descriptors>-->
-          <!--<decriptor>src/main/assembly/assembly.xml</decriptor>-->
-          <!--</descriptors>-->
           <appendAssemblyId>false</appendAssemblyId>
           <descriptorRefs>
             <descriptorRef>jar-with-dependencies</descriptorRef>
           </descriptorRefs>
         </configuration>
-        <executions>
+        <!-- <executions>
           <execution>
             <id>assembly</id>
             <phase>package</phase>
@@ -256,7 +253,7 @@
               <goal>single</goal>
             </goals>
           </execution>
-        </executions>
+        </executions> -->
       </plugin>
 
       <plugin>

--- a/core/raydp-main/src/main/scala/org/apache/spark/deploy/raydp/RayAppMaster.scala
+++ b/core/raydp-main/src/main/scala/org/apache/spark/deploy/raydp/RayAppMaster.scala
@@ -124,7 +124,7 @@ class RayAppMaster(host: String,
 
     private val bundleIndexesNum: Int = bundleIndexesOpt match {
         case Some(n) => n.size
-        case None    => 0
+        case None => 0
       }
 
     private var currentBundleIndex: Int = 0

--- a/core/raydp-main/src/main/scala/org/apache/spark/deploy/raydp/RayAppMaster.scala
+++ b/core/raydp-main/src/main/scala/org/apache/spark/deploy/raydp/RayAppMaster.scala
@@ -19,7 +19,7 @@ package org.apache.spark.deploy.raydp
 
 import java.io.File
 import java.text.SimpleDateFormat
-import java.util.{Date, Locale}
+import java.util.{Arrays, Date, List, Locale}
 import javax.xml.bind.DatatypeConverter
 
 import scala.collection.JavaConverters._
@@ -120,8 +120,8 @@ class RayAppMaster(host: String,
         PlacementGroups.getPlacementGroup(id)
       }.orNull
     private val bundleIndexes: List[Int] = conf.getOption("spark.ray.bundle_indexes")
-      .map(_.split(",").map(_.toInt).toList)
-      .getOrElse(List.empty)
+      .map(_.split(",").map(_.toInt).toList).get.asJava
+
     private var currentBundleIndex: Int = 0
 
     override def receive: PartialFunction[Any, Unit] = {
@@ -316,7 +316,7 @@ class RayAppMaster(host: String,
     }
 
     private def getNextBundleIndex: Int = {
-      if (placementGroup != null && bundleIndexes.nonEmpty) {
+      if (placementGroup != null && !bundleIndexes.isEmpty) {
         val previous = currentBundleIndex
         currentBundleIndex = (currentBundleIndex + 1) % bundleIndexes.size
         previous

--- a/core/raydp-main/src/main/scala/org/apache/spark/deploy/raydp/RayAppMaster.scala
+++ b/core/raydp-main/src/main/scala/org/apache/spark/deploy/raydp/RayAppMaster.scala
@@ -19,7 +19,7 @@ package org.apache.spark.deploy.raydp
 
 import java.io.File
 import java.text.SimpleDateFormat
-import java.util.{Arrays, Date, List, Locale}
+import java.util.{Date, Locale}
 import javax.xml.bind.DatatypeConverter
 
 import scala.collection.JavaConverters._
@@ -119,9 +119,13 @@ class RayAppMaster(host: String,
         val id = PlacementGroupId.fromBytes(DatatypeConverter.parseHexBinary(hex))
         PlacementGroups.getPlacementGroup(id)
       }.orNull
-    private val bundleIndexes: List[Int] = conf.getOption("spark.ray.bundle_indexes")
-      .map(_.split(",").map(_.toInt).toList)
-      .getOrElse(List.empty).asJava
+    private val bundleIndexesOpt: Option[Array[Int]] = conf.getOption("spark.ray.bundle_indexes")
+      .map(_.split(",").map(_.toInt))
+
+    private val bundleIndexesNum: Int = bundleIndexesOpt match {
+        case Some(n) => n.size
+        case None    => 0
+      }
 
     private var currentBundleIndex: Int = 0
 
@@ -317,9 +321,9 @@ class RayAppMaster(host: String,
     }
 
     private def getNextBundleIndex: Int = {
-      if (placementGroup != null && !bundleIndexes.isEmpty) {
+      if (placementGroup != null && bundleIndexesNum != 0) {
         val previous = currentBundleIndex
-        currentBundleIndex = (currentBundleIndex + 1) % bundleIndexes.size
+        currentBundleIndex = (currentBundleIndex + 1) % bundleIndexesNum
         previous
       } else {
         -1

--- a/core/raydp-main/src/main/scala/org/apache/spark/deploy/raydp/RayAppMaster.scala
+++ b/core/raydp-main/src/main/scala/org/apache/spark/deploy/raydp/RayAppMaster.scala
@@ -120,7 +120,8 @@ class RayAppMaster(host: String,
         PlacementGroups.getPlacementGroup(id)
       }.orNull
     private val bundleIndexes: List[Int] = conf.getOption("spark.ray.bundle_indexes")
-      .map(_.split(",").map(_.toInt).toList).get.asJava
+      .map(_.split(",").map(_.toInt).toList)
+      .getOrElse(List.empty).asJava
 
     private var currentBundleIndex: Int = 0
 

--- a/core/shims/spark322/pom.xml
+++ b/core/shims/spark322/pom.xml
@@ -17,7 +17,7 @@
 
   <properties>
     <scala.version>2.12.15</scala.version>
-    <jackson.version>2.12.0</jackson.version>
+    <jackson.version>2.13.5</jackson.version>
   </properties>
 
   <build>

--- a/core/shims/spark330/pom.xml
+++ b/core/shims/spark330/pom.xml
@@ -17,7 +17,7 @@
 
   <properties>
     <scala.version>2.12.15</scala.version>
-    <jackson.version>2.13.3</jackson.version>
+    <jackson.version>2.13.5</jackson.version>
   </properties>
 
   <build>

--- a/core/shims/spark340/pom.xml
+++ b/core/shims/spark340/pom.xml
@@ -17,7 +17,7 @@
 
   <properties>
     <scala.version>2.12.15</scala.version>
-    <jackson.version>2.13.3</jackson.version>
+    <jackson.version>2.13.5</jackson.version>
   </properties>
 
   <build>


### PR DESCRIPTION
Fix two vulnerabilities of RayDP 1.6 and ready for release:

Scala:
![image](https://github.com/oap-project/raydp/assets/25916266/1e2cbc9a-ffda-479f-ad47-0f72cc2a5666)


Jackson:
![image](https://github.com/oap-project/raydp/assets/25916266/cdc199d6-3602-40af-9b08-8d5e28d9feda)
