### PR TITLE
Upgrade snappy version to fix CVE issue

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -17,7 +17,7 @@
     <spark322.version>3.2.2</spark322.version>
     <spark330.version>3.3.0</spark330.version>
     <spark340.version>3.4.0</spark340.version>
-    <snappy.version>1.1.10.1</snappy.version>
+    <snappy.version>1.1.10.4</snappy.version>
     <netty.version>4.1.94.Final</netty.version>
     <commons.text.version>1.10.0</commons.text.version>
     <commons.compress.version>1.21</commons.compress.version>


### PR DESCRIPTION
To fix following CVE issue:

![image](https://github.com/oap-project/raydp/assets/25916266/51a946a9-15f4-416e-b482-d3c8e7974efc)
