### PR TITLE
Changes for executor actor recovery using ray's fault tolerance.

### DIFF
--- a/core/raydp-main/src/main/java/org/apache/spark/raydp/RayExecutorUtils.java
+++ b/core/raydp-main/src/main/java/org/apache/spark/raydp/RayExecutorUtils.java
@@ -60,8 +60,8 @@ public class RayExecutorUtils {
     if (placementGroup != null) {
       creator.setPlacementGroup(placementGroup, bundleIndex);
     }
-    creator.setMaxRestarts(3);
-    creator.setMaxTaskRetries(3);
+    creator.setMaxRestarts(-1);
+    creator.setMaxTaskRetries(-1);
     creator.setMaxConcurrency(2);
     return creator.remote();
   }

--- a/core/raydp-main/src/main/scala/org/apache/spark/deploy/raydp/RayAppMaster.scala
+++ b/core/raydp-main/src/main/scala/org/apache/spark/deploy/raydp/RayAppMaster.scala
@@ -183,7 +183,7 @@ class RayAppMaster(host: String,
         assert(appInfo != null && appInfo.id == appId)
         var success = true
         for (executorId <- executorIds) {
-          if (!appInfo.kill(executorId)) {
+          if (!appInfo.kill(executorId, shutdownActor = true)) {
             success = false
           }
         }
@@ -210,7 +210,7 @@ class RayAppMaster(host: String,
     }
 
     override def onDisconnected(remoteAddress: RpcAddress): Unit = {
-      appInfo.kill(remoteAddress)
+      appInfo.kill(remoteAddress, shutdownActor = false)
     }
 
     override def onStop(): Unit = {


### PR DESCRIPTION
Pull request for the bug described in the issue https://github.com/oap-project/raydp/issues/364.

This is the fix for ray executors not recovering from OOM and other failures.
The issue is because of the race condition:

```
 - Executor E1 dies lets say because of OOM
 - We try to kill it by firing stop call on E1 actor
 - Since the actor is not available, the stop task fails for E1
 - In the mean while, ray brings up the lost executor E1
 - The failed task (stop task) gets retried as there are task retries configured.
 - The stop task gets fired on the new executor which got recovered
 - The Recovered executor exits with status as user intended exit.
```