### PR TITLE
dynamic allocation executor pending for addition flood fix

### DIFF
--- a/core/raydp-main/src/main/scala/org/apache/spark/deploy/raydp/RayAppMaster.scala
+++ b/core/raydp-main/src/main/scala/org/apache/spark/deploy/raydp/RayAppMaster.scala
@@ -270,8 +270,8 @@ class RayAppMaster(host: String,
           .map{ case (name, amount) => s"${name}: ${amount}"}.mkString(", ")} }..")
       // TODO: Support generic fractional logical resources using prefix spark.ray.actor.resource.*
 
-      //This will check with dynamic auto scale no additional pending executor actor added more than max
-      // executors count as this result in executor even running after job completion
+      //This will check with dynamic auto scale no additional pending executor actor added more
+      // than max executors count as this result in executor even running after job completion
       val dynamicAllocationEnabled = conf.getBoolean("spark.dynamicAllocation.enabled", false)
       if (dynamicAllocationEnabled) {
         val maxExecutor = conf.getInt("spark.dynamicAllocation.maxExecutors", 0)

--- a/core/raydp-main/src/main/scala/org/apache/spark/deploy/raydp/RayAppMaster.scala
+++ b/core/raydp-main/src/main/scala/org/apache/spark/deploy/raydp/RayAppMaster.scala
@@ -270,7 +270,7 @@ class RayAppMaster(host: String,
           .map{ case (name, amount) => s"${name}: ${amount}"}.mkString(", ")} }..")
       // TODO: Support generic fractional logical resources using prefix spark.ray.actor.resource.*
 
-      //This will check with dynamic auto scale no additional pending executor actor added more
+      // This will check with dynamic auto scale no additional pending executor actor added more
       // than max executors count as this result in executor even running after job completion
       val dynamicAllocationEnabled = conf.getBoolean("spark.dynamicAllocation.enabled", false)
       if (dynamicAllocationEnabled) {

--- a/core/raydp-main/src/main/scala/org/apache/spark/deploy/raydp/RayAppMaster.scala
+++ b/core/raydp-main/src/main/scala/org/apache/spark/deploy/raydp/RayAppMaster.scala
@@ -270,8 +270,8 @@ class RayAppMaster(host: String,
           .map{ case (name, amount) => s"${name}: ${amount}"}.mkString(", ")} }..")
       // TODO: Support generic fractional logical resources using prefix spark.ray.actor.resource.*
 
-      //This will check with dynamic auto scale no additional pending executor actor added more than max executors count
-      // as this result in executor even running after job completion
+      //This will check with dynamic auto scale no additional pending executor actor added more than max
+      // executors count as this result in executor even running after job completion
       val dynamicAllocationEnabled = conf.getBoolean("spark.dynamicAllocation.enabled", false)
       if (dynamicAllocationEnabled) {
         val maxExecutor = conf.getInt("spark.dynamicAllocation.maxExecutors", 0)

--- a/core/raydp-main/src/main/scala/org/apache/spark/deploy/raydp/RayAppMaster.scala
+++ b/core/raydp-main/src/main/scala/org/apache/spark/deploy/raydp/RayAppMaster.scala
@@ -270,6 +270,16 @@ class RayAppMaster(host: String,
           .map{ case (name, amount) => s"${name}: ${amount}"}.mkString(", ")} }..")
       // TODO: Support generic fractional logical resources using prefix spark.ray.actor.resource.*
 
+      //This will check with dynamic auto scale no additional pending executor actor added more than max executors count
+      // as this result in executor even running after job completion
+      val dynamicAllocationEnabled = conf.getBoolean("spark.dynamicAllocation.enabled", false)
+      if (dynamicAllocationEnabled) {
+        val maxExecutor = conf.getInt("spark.dynamicAllocation.maxExecutors", 0)
+        if (restartedExecutors.size >= maxExecutor) {
+          return
+        }
+      }
+
       val handler = RayExecutorUtils.createExecutorActor(
         executorId, getAppMasterEndpointUrl(),
         rayActorCPU,


### PR DESCRIPTION
## Overview 
Issue : 
Currently with dynamic allocation for executors there are too many executors pending to be added while the actual number of max executor is far less 

Solution:
This will check with dynamic auto scale no additional pending executor actor added more than max executors count
as this result in executor even running after job completion