### PR TITLE
Resolve NPE Caused by Missing EXECUTOR_INSTANCES in Spark Settings.

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -32,6 +32,7 @@
     <scala.version>2.12.15</scala.version>
     <jackson.version>2.13.5</jackson.version>
     <scala.binary.version>2.12</scala.binary.version>
+    <junit-jupiter.version>5.10.1</junit-jupiter.version>
   </properties>
 
   <modules>
@@ -178,6 +179,19 @@
         <groupId>com.fasterxml.jackson.module</groupId>
         <artifactId>jackson-module-jaxb-annotations</artifactId>
         <version>${jackson.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter</artifactId>
+        <version>${junit-jupiter.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-api</artifactId>
+        <version>${junit-jupiter.version}</version>
+        <scope>test</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/core/raydp-main/pom.xml
+++ b/core/raydp-main/pom.xml
@@ -165,6 +165,16 @@
       <version>${jackson.version}</version>
     </dependency>
 
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/core/raydp-main/src/main/java/org/apache/spark/raydp/SparkOnRayConfigs.java
+++ b/core/raydp-main/src/main/java/org/apache/spark/raydp/SparkOnRayConfigs.java
@@ -116,4 +116,6 @@ public class SparkOnRayConfigs {
      */
     public static final String RAYDP_LOGFILE_PREFIX_CFG =
             "-Dray.logging.file-prefix=raydp-java-worker";
+
+    public static final int DEFAULT_SPARK_EXECUTOR_INSTANCES = 1;
 }

--- a/core/raydp-main/src/main/java/org/apache/spark/raydp/SparkOnRayConfigs.java
+++ b/core/raydp-main/src/main/java/org/apache/spark/raydp/SparkOnRayConfigs.java
@@ -116,9 +116,4 @@ public class SparkOnRayConfigs {
      */
     public static final String RAYDP_LOGFILE_PREFIX_CFG =
             "-Dray.logging.file-prefix=raydp-java-worker";
-
-    /**
-     *  Default value for the number of Spark executor instances.
-     */
-    public static final int DEFAULT_SPARK_EXECUTOR_INSTANCES = 1;
 }

--- a/core/raydp-main/src/main/java/org/apache/spark/raydp/SparkOnRayConfigs.java
+++ b/core/raydp-main/src/main/java/org/apache/spark/raydp/SparkOnRayConfigs.java
@@ -117,5 +117,8 @@ public class SparkOnRayConfigs {
     public static final String RAYDP_LOGFILE_PREFIX_CFG =
             "-Dray.logging.file-prefix=raydp-java-worker";
 
+    /**
+     *  Default value for the number of Spark executor instances.
+     */
     public static final int DEFAULT_SPARK_EXECUTOR_INSTANCES = 1;
 }

--- a/core/raydp-main/src/main/scala/org/apache/spark/scheduler/cluster/raydp/RayCoarseGrainedSchedulerBackend.scala
+++ b/core/raydp-main/src/main/scala/org/apache/spark/scheduler/cluster/raydp/RayCoarseGrainedSchedulerBackend.scala
@@ -20,23 +20,20 @@ package org.apache.spark.scheduler.cluster.raydp
 import java.net.URI
 import java.util.concurrent.Semaphore
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
-
 import scala.collection.JavaConverters._
 import scala.collection.mutable.HashMap
 import scala.concurrent.Future
-
 import io.ray.api.{ActorHandle, Ray}
-
 import org.apache.spark.{RayDPException, SparkConf, SparkContext, SparkException}
 import org.apache.spark.deploy.raydp._
 import org.apache.spark.deploy.security.HadoopDelegationTokenManager
-import org.apache.spark.internal.{config, Logging}
+import org.apache.spark.internal.{Logging, config}
 import org.apache.spark.launcher.{LauncherBackend, SparkAppHandle}
 import org.apache.spark.raydp.SparkOnRayConfigs
 import org.apache.spark.resource.{ResourceProfile, ResourceRequirement, ResourceUtils}
 import org.apache.spark.rpc.{RpcEndpointAddress, RpcEndpointRef, RpcEnv, ThreadSafeRpcEndpoint}
 import org.apache.spark.scheduler.TaskSchedulerImpl
-import org.apache.spark.scheduler.cluster.CoarseGrainedSchedulerBackend
+import org.apache.spark.scheduler.cluster.{CoarseGrainedSchedulerBackend, SchedulerBackendUtils}
 import org.apache.spark.util.Utils
 
 /**
@@ -171,8 +168,7 @@ class RayCoarseGrainedSchedulerBackend(
 
     val resourcesInMap = transferResourceRequirements(executorResourceReqs) ++
       raydpExecutorCustomResources
-    val numExecutors = conf.get(config.EXECUTOR_INSTANCES)
-      .getOrElse(SparkOnRayConfigs.DEFAULT_SPARK_EXECUTOR_INSTANCES)
+    val numExecutors = SchedulerBackendUtils.getInitialTargetExecutorNumber(conf);
     val sparkCoresPerExecutor = coresPerExecutor
       .getOrElse(SparkOnRayConfigs.DEFAULT_SPARK_CORES_PER_EXECUTOR)
     val rayActorCPU = conf.get(SparkOnRayConfigs.SPARK_EXECUTOR_ACTOR_CPU_RESOURCE,

--- a/core/raydp-main/src/main/scala/org/apache/spark/scheduler/cluster/raydp/RayCoarseGrainedSchedulerBackend.scala
+++ b/core/raydp-main/src/main/scala/org/apache/spark/scheduler/cluster/raydp/RayCoarseGrainedSchedulerBackend.scala
@@ -26,6 +26,7 @@ import scala.collection.mutable.HashMap
 import scala.concurrent.Future
 
 import io.ray.api.{ActorHandle, Ray}
+
 import org.apache.spark.{RayDPException, SparkConf, SparkContext, SparkException}
 import org.apache.spark.deploy.raydp._
 import org.apache.spark.deploy.security.HadoopDelegationTokenManager

--- a/core/raydp-main/src/main/scala/org/apache/spark/scheduler/cluster/raydp/RayCoarseGrainedSchedulerBackend.scala
+++ b/core/raydp-main/src/main/scala/org/apache/spark/scheduler/cluster/raydp/RayCoarseGrainedSchedulerBackend.scala
@@ -171,7 +171,8 @@ class RayCoarseGrainedSchedulerBackend(
 
     val resourcesInMap = transferResourceRequirements(executorResourceReqs) ++
       raydpExecutorCustomResources
-    val numExecutors = conf.get(config.EXECUTOR_INSTANCES).get
+    val numExecutors = conf.get(config.EXECUTOR_INSTANCES)
+      .getOrElse(SparkOnRayConfigs.DEFAULT_SPARK_EXECUTOR_INSTANCES)
     val sparkCoresPerExecutor = coresPerExecutor
       .getOrElse(SparkOnRayConfigs.DEFAULT_SPARK_CORES_PER_EXECUTOR)
     val rayActorCPU = conf.get(SparkOnRayConfigs.SPARK_EXECUTOR_ACTOR_CPU_RESOURCE,

--- a/core/raydp-main/src/main/scala/org/apache/spark/scheduler/cluster/raydp/RayCoarseGrainedSchedulerBackend.scala
+++ b/core/raydp-main/src/main/scala/org/apache/spark/scheduler/cluster/raydp/RayCoarseGrainedSchedulerBackend.scala
@@ -20,14 +20,16 @@ package org.apache.spark.scheduler.cluster.raydp
 import java.net.URI
 import java.util.concurrent.Semaphore
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
+
 import scala.collection.JavaConverters._
 import scala.collection.mutable.HashMap
 import scala.concurrent.Future
+
 import io.ray.api.{ActorHandle, Ray}
 import org.apache.spark.{RayDPException, SparkConf, SparkContext, SparkException}
 import org.apache.spark.deploy.raydp._
 import org.apache.spark.deploy.security.HadoopDelegationTokenManager
-import org.apache.spark.internal.{Logging, config}
+import org.apache.spark.internal.{config, Logging}
 import org.apache.spark.launcher.{LauncherBackend, SparkAppHandle}
 import org.apache.spark.raydp.SparkOnRayConfigs
 import org.apache.spark.resource.{ResourceProfile, ResourceRequirement, ResourceUtils}

--- a/core/raydp-main/src/main/test/org/apache/spark/scheduler/cluster/raydp/TestRayCoarseGrainedSchedulerBackend.java
+++ b/core/raydp-main/src/main/test/org/apache/spark/scheduler/cluster/raydp/TestRayCoarseGrainedSchedulerBackend.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.scheduler.cluster.raydp;
+
+import org.apache.spark.SparkConf;
+import org.junit.jupiter.api.Test;
+
+import org.apache.spark.scheduler.cluster.SchedulerBackendUtils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TestRayCoarseGrainedSchedulerBackend {
+  @Test
+  public void testExecutorNumberWithDefaultConfig() {
+    SparkConf conf = new SparkConf();
+    int executorNumber = SchedulerBackendUtils.getInitialTargetExecutorNumber(conf, 2);
+    assertEquals(2, executorNumber);
+  }
+
+  @Test
+  public void testExecutorNumberWithNegativeConfig() {
+    SparkConf conf = new SparkConf();
+    conf.set("spark.dynamicAllocation.initialExecutors", "-1");
+    int executorNumber = SchedulerBackendUtils.getInitialTargetExecutorNumber(conf, 2);
+    assertEquals(2, executorNumber);
+  }
+
+  @Test
+  public void testExecutorNumberWithValidConfig() {
+    SparkConf conf = new SparkConf();
+    conf.set("spark.executor.instances", "5");
+    int executorNumber = SchedulerBackendUtils.getInitialTargetExecutorNumber(conf, 2);
+    assertEquals(5, executorNumber);
+  }
+
+  @Test
+  public void testExecutorNumberWithDynamicConfig() {
+    SparkConf conf = new SparkConf();
+    conf.set("spark.dynamicAllocation.enabled", "true");
+    conf.set("spark.dynamicAllocation.minExecutors", "3");
+    int executorNumber = SchedulerBackendUtils.getInitialTargetExecutorNumber(conf, 2);
+    assertEquals(3, executorNumber);
+  }
+}

--- a/core/raydp-main/src/main/test/org/apache/spark/scheduler/cluster/raydp/TestRayCoarseGrainedSchedulerBackend.java
+++ b/core/raydp-main/src/main/test/org/apache/spark/scheduler/cluster/raydp/TestRayCoarseGrainedSchedulerBackend.java
@@ -23,7 +23,12 @@ import org.apache.spark.scheduler.cluster.SchedulerBackendUtils;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+/**
+ * This class performs unit testing on some methods in `RayCoarseGrainedSchedulerBackend`.
+ */
 public class TestRayCoarseGrainedSchedulerBackend {
+
+  // Test using the default value.
   @Test
   public void testExecutorNumberWithDefaultConfig() {
     SparkConf conf = new SparkConf();
@@ -31,6 +36,7 @@ public class TestRayCoarseGrainedSchedulerBackend {
     assertEquals(2, executorNumber);
   }
 
+  // Test using a negative value.
   @Test
   public void testExecutorNumberWithNegativeConfig() {
     SparkConf conf = new SparkConf();
@@ -39,6 +45,7 @@ public class TestRayCoarseGrainedSchedulerBackend {
     assertEquals(2, executorNumber);
   }
 
+  // Test using reasonable values.
   @Test
   public void testExecutorNumberWithValidConfig() {
     SparkConf conf = new SparkConf();
@@ -47,6 +54,7 @@ public class TestRayCoarseGrainedSchedulerBackend {
     assertEquals(5, executorNumber);
   }
 
+  // Test using dynamic values.
   @Test
   public void testExecutorNumberWithDynamicConfig() {
     SparkConf conf = new SparkConf();


### PR DESCRIPTION
> Backgroud

During our testing, we found that when using RayDP and the `spark.executor.instances` parameter is not specified, a null pointer exception is thrown.

I believe we should set a default value for this parameter. If the user does not specify it, we should use the default value instead of throwing an exception. This would improve the user experience.

The error message is as follows:

```
25/02/20 22:58:59 ERROR SparkContext: Error initializing SparkContext.
java.util.NoSuchElementException: None.get
	at scala.None$.get(Option.scala:529)
	at scala.None$.get(Option.scala:527)
	at org.apache.spark.scheduler.cluster.raydp.RayCoarseGrainedSchedulerBackend.start(RayCoarseGrainedSchedulerBackend.scala:174)
	at org.apache.spark.scheduler.TaskSchedulerImpl.start(TaskSchedulerImpl.scala:220)
	at org.apache.spark.SparkContext.<init>(SparkContext.scala:584)
	at org.apache.spark.api.java.JavaSparkContext.<init>(JavaSparkContext.scala:58)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
	at py4j.reflection.MethodInvoker.invoke(MethodInvoker.java:247)
	at py4j.reflection.ReflectionEngine.invoke(ReflectionEngine.java:357)
	at py4j.Gateway.invoke(Gateway.java:238)
	at py4j.commands.ConstructorCommand.invokeConstructor(ConstructorCommand.java:80)
	at py4j.commands.ConstructorCommand.execute(ConstructorCommand.java:69)
	at py4j.ClientServerConnection.waitForCommands(ClientServerConnection.java:182)
	at py4j.ClientServerConnection.run(ClientServerConnection.java:106)
	at java.lang.Thread.run(Thread.java:745)
25/02/20 22:58:59 INFO AbstractConnector: Stopped Spark@22f7fd5e{HTTP/1.1, (http/1.1)}{0.0.0.0:4040}
25/02/20 22:59:00 ERROR Utils: Uncaught exception in thread Thread-4
java.lang.NullPointerException
	at org.apache.spark.scheduler.cluster.raydp.RayCoarseGrainedSchedulerBackend.org$apache$spark$scheduler$cluster$raydp$RayCoarseGrainedSchedulerBackend$$stop(RayCoarseGrainedSchedulerBackend.scala:309)
	at org.apache.spark.scheduler.cluster.raydp.RayCoarseGrainedSchedulerBackend.stop(RayCoarseGrainedSchedulerBackend.scala:197)
	at org.apache.spark.scheduler.TaskSchedulerImpl.stop(TaskSchedulerImpl.scala:927)
	at org.apache.spark.scheduler.DAGScheduler.stop(DAGScheduler.scala:2516)
	at org.apache.spark.SparkContext.$anonfun$stop$12(SparkContext.scala:2089)
	at org.apache.spark.util.Utils$.tryLogNonFatalError(Utils.scala:1442)
	at org.apache.spark.SparkContext.stop(SparkContext.scala:2089)
	at org.apache.spark.SparkContext.<init>(SparkContext.scala:680)
....
```