### PR TITLE
Fix Some Typos in ReadME.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ spark = raydp.init_spark(app_name='RayDP Example',
                          executor_cores=2,
                          executor_memory='4GB')
 
-# normal data processesing with Spark
+# normal data processing with Spark
 df = spark.createDataFrame([('look',), ('spark',), ('tutorial',), ('spark',), ('look', ), ('python', )], ['word'])
 df.show()
 word_count = df.groupBy('word').count()

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,7 +1,7 @@
 # RayDP Examples
 Here are a few examples showing how RayDP works together with other libraries, such as PyTorch, Tensorflow, XGBoost and Horovod. 
 
-In order to run these examples, you may need to install corresponding dependencies. For installation guides, please refer to their homepages. Notice that we need to install [xgboost_ray](https://github.com/ray-project/xgboost_ray) to run the xgboost example. In addition, if you are running the examples in a ray cluster, all nodes should have the dependecies installed.
+In order to run these examples, you may need to install corresponding dependencies. For installation guides, please refer to their homepages. Notice that we need to install [xgboost_ray](https://github.com/ray-project/xgboost_ray) to run the xgboost example. In addition, if you are running the examples in a ray cluster, all nodes should have the dependencies installed.
 
 ## NYC Taxi Fare Prediction Dataset
 We have a few examples which use this dataset.
@@ -10,7 +10,7 @@ You can run our examples right away after you clone our repo, because we include
 The original dataset can be downloaded [here](https://www.kaggle.com/c/new-york-city-taxi-fare-prediction/data). After you download it, please modify the variable `NYC_TRAIN_CSV` in `data_process.py` and point it to where `train.csv` is saved.
 
 ## Horovod
-To run the example, please intall horovod via `pip install horovod[pytorch, ray]`. In addtion, `HOROVOD_WITH_PYTORCH` and `HOROVOD_WITH_GLOO` should be set to `1` before pip. Notice that macOS users need to first install `libuv` via `brew install libuv`. Please refer to [here](https://horovod.readthedocs.io/en/stable/install_include.html) for details.
+To run the example, please install horovod via `pip install horovod[pytorch, ray]`. In addition, `HOROVOD_WITH_PYTORCH` and `HOROVOD_WITH_GLOO` should be set to `1` before pip. Notice that macOS users need to first install `libuv` via `brew install libuv`. Please refer to [here](https://horovod.readthedocs.io/en/stable/install_include.html) for details.
 
 When running `horovod_nyctaxi.py`, do not use `horovodrun`. Check [here](https://horovod.readthedocs.io/en/stable/ray_include.html) for more information. 
 


### PR DESCRIPTION
We are currently trying to use RayDP, and during the process of reading the documentation, I noticed some typos in the README.md. This PR aims to fix them.