### PR TITLE
Resolve Driver Host Recognition Issue in RayDP Executor.

### DIFF
--- a/bin/raydp-submit
+++ b/bin/raydp-submit
@@ -44,6 +44,10 @@ fi
 if [ -z "${RAY_HOME}" ]; then
   RAY_HOME=$(python3 -c "import os, ray; print(os.path.dirname(ray.__file__))")
 fi
+# set RAY_DRIVER_NODE_IP
+if [ -z "${RAY_DRIVER_NODE_IP}" ]; then
+  RAY_DRIVER_NODE_IP=$(python3 -c "import ray; print(ray.util.get_node_ip_address())")
+fi
 
 
 # set log4j versions for spark driver and executors inside ray worker
@@ -115,6 +119,10 @@ added_confs+=("-D$SPARK_LOG4J_CONFIG_FILE_NAME_KEY=$SPARK_LOG4J_CONFIG_FILE_NAME
 added_confs+=("-Dspark.javaagent=$raydp_agent_jar")
 added_args+=("--conf")
 added_args+=("spark.ray.log4j.config.file.name=$RAY_LOG4J_CONFIG_FILE_NAME")
+added_args+=("--conf")
+added_args+=("spark.driver.host=$RAY_DRIVER_NODE_IP")
+added_args+=("--conf")
+added_args+=("spark.driver.bindAddress=$RAY_DRIVER_NODE_IP")
 
 # Find the java binary
 if [ -n "${JAVA_HOME}" ]; then


### PR DESCRIPTION
> Background

While using RayDP, we encountered an issue where tasks submitted via the RayDpSubmit script result in the Executor failing to register with the Driver. However, this issue does not occur when using the example code directly.

The following method does not result in the Executor being unable to allocate resources:

```
import ray
import raydp

# connect to ray cluster
ray.init(address='auto')

# create a Spark cluster with specified resource requirements
spark = raydp.init_spark(app_name='RayDP Example',
                         num_executors=2,
                         executor_cores=2,
                         executor_memory='4GB')

# normal data processesing with Spark
df = spark.createDataFrame([('look',), ('spark',), ('tutorial',), ('spark',), ('look', ), ('python', )], ['word'])
df.show()
word_count = df.groupBy('word').count()
word_count.show()

# stop the spark cluster
raydp.stop_spark()
```

However, if we submit the code directly using the `bin/raydp-submit` script, there may be cases where the Executor fails to allocate resources.

After thorough investigation, I identified the root cause of the issue. The problem arises from the specific network configuration in our environment. We did not use the `hostNetwork` mode in K8s, but instead built a local network using `svc`.

We submitted a RayJob through KubeRay, which first creates a small Ray cluster. This small cluster is created using a `svc`-based network. If we do not explicitly set `spark.driver.host`, the Executor will use the domain name of the head node instead of its IP address when it is created.

Since the Worker nodes do not know the mapping between the head node's domain name and IP address, they are unable to register with the Driver.

However, if we use the example code, the `ray_cluster.py` script will set `spark.driver.host` and `spark.driver.bindAddress`. 

We can refer to the code below.

https://github.com/oap-project/raydp/blob/f31fec6ca5d2efa48b2e84346839679be4fe7085/python/raydp/spark/ray_cluster.py#L116-L121

> Method to solve

We set the driver's `spark.driver.host` and `spark.driver.bindAddress` in the `raydp-submit` script.
