### PR TITLE
Standardize executor limit enforcement for dynamic and static allocation

### DIFF
--- a/core/raydp-main/src/main/scala/org/apache/spark/deploy/raydp/RayAppMaster.scala
+++ b/core/raydp-main/src/main/scala/org/apache/spark/deploy/raydp/RayAppMaster.scala
@@ -273,10 +273,19 @@ class RayAppMaster(host: String,
       // This will check with dynamic auto scale no additional pending executor actor added more
       // than max executors count as this result in executor even running after job completion
       val dynamicAllocationEnabled = conf.getBoolean("spark.dynamicAllocation.enabled", false)
+      // FIX: Check total executors (current + restarted) against maxExecutor, executorInstances
       if (dynamicAllocationEnabled) {
         val maxExecutor = conf.getInt("spark.dynamicAllocation.maxExecutors", 0)
-        if (restartedExecutors.size >= maxExecutor) {
+        if ((appInfo.executors.size + restartedExecutors.size) >= maxExecutor) {
           return
+        }
+      }
+      else {
+        val executorInstances = conf.getInt("spark.executor.instances", 0)
+        if (executorInstances != 0) {
+          if((appInfo.executors.size + restartedExecutors.size) >=  executorInstances) {
+            return
+          }
         }
       }
 


### PR DESCRIPTION
There's a bug in how it enforces the maxExecutor boundary.
In the dynamic allocation section, it only checks:
restartedExecutors

```
if (restartedExecutors.size >= maxExecutor) {
  return
}
```
But this only counts the restartedExecutors, not all executors. Meanwhile,   properly we should check the total:
This correctly checks total executors
```

if((appInfo.executors.size + restartedExecutors.size) >= executorInstances) {
  return
}
```
The fix would be to modify the dynamic allocation condition to match the static allocation approach:
```

if (dynamicAllocationEnabled) {
  val maxExecutor = conf.getInt("spark.dynamicAllocation.maxExecutors", 0)
  if ((appInfo.executors.size + restartedExecutors.size) >= maxExecutor) {
    return
  }
}
```
This bug explains exactly why we are getting maxExecutor set to 3 but 4 pods/machines available, it keeps creating executors until it hits the physical limit rather than respecting your configured maximum.

Static Allocation:
This handles executor scaling when Spark's dynamic allocation is disabled:
```
      else {
        val executorInstances = conf.getInt("spark.executor.instances", 0)
        if (executorInstances != 0) {
          if((appInfo.executors.size + restartedExecutors.size) >=  executorInstances) {
            return
          }
        }
      }
```